### PR TITLE
AP-27 OAuth

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,11 +2,11 @@ package client
 
 import (
     "log"
-	"fmt"
+    "fmt"
     "net/http"
     "net/url"
-    "time"
     "os"
+    "time"
 
     "github.com/gorilla/websocket"
     "github.com/thecoderstudio/apollo-agent/oauth"

--- a/client/client.go
+++ b/client/client.go
@@ -5,7 +5,6 @@ import (
     "fmt"
     "net/http"
     "net/url"
-    "os"
     "time"
 
     "github.com/gorilla/websocket"
@@ -41,7 +40,7 @@ type client struct {
 // Listen connects to the given endpoint and handles incoming messages. It's interruptable
 // by closing the interrupt channel.
 func (client *client) Listen(endpointURL url.URL, accessToken oauth.AccessToken,
-                             interrupt *chan os.Signal) (<-chan string, <-chan struct{}, <-chan error) {
+                             interrupt *chan struct{}) (<-chan string, <-chan struct{}, <-chan error) {
     out := make(chan string)
     errs := make(chan error)
     done := make(chan struct{})
@@ -104,7 +103,7 @@ func (client *client) awaitMessages(connection *WebsocketConn, out *chan string,
 }
 
 func (client *client) handleEvents(connection *WebsocketConn, doneListening *chan struct{},
-                                   interrupt *chan os.Signal) error {
+                                   interrupt *chan struct{}) error {
     for {
         select {
         case <-*doneListening:

--- a/client/client.go
+++ b/client/client.go
@@ -2,12 +2,14 @@ package client
 
 import (
     "log"
+	"fmt"
     "net/http"
     "net/url"
     "time"
     "os"
 
     "github.com/gorilla/websocket"
+    "github.com/thecoderstudio/apollo-agent/oauth"
 )
 
 // WebsocketConn specifies the interface for client connection
@@ -38,7 +40,8 @@ type client struct {
 
 // Listen connects to the given endpoint and handles incoming messages. It's interruptable
 // by closing the interrupt channel.
-func (client *client) Listen(endpointURL url.URL, interrupt *chan os.Signal) (<-chan string, <-chan struct{}, <-chan error) {
+func (client *client) Listen(endpointURL url.URL, accessToken oauth.AccessToken,
+                             interrupt *chan os.Signal) (<-chan string, <-chan struct{}, <-chan error) {
     out := make(chan string)
     errs := make(chan error)
     done := make(chan struct{})
@@ -47,7 +50,7 @@ func (client *client) Listen(endpointURL url.URL, interrupt *chan os.Signal) (<-
         defer close(out)
         defer close(errs)
 
-        connection, err := client.createConnection(endpointURL)
+        connection, err := client.createConnection(endpointURL, accessToken)
         if err != nil {
             log.Println("Connection error")
             errs <- err
@@ -70,10 +73,11 @@ func (client *client) Listen(endpointURL url.URL, interrupt *chan os.Signal) (<-
     return out, done, errs
 }
 
-func (client *client) createConnection(endpointURL url.URL) (WebsocketConn, error) {
+func (client *client) createConnection(endpointURL url.URL, accessToken oauth.AccessToken) (WebsocketConn, error) {
     urlString := endpointURL.String()
     log.Printf("connecting to %s", urlString)
-    connection, _, err := client.dialer.Dial(urlString, nil)
+    authorizationHeader := fmt.Sprintf("%s %s", accessToken.TokenType, accessToken.AccessToken)
+    connection, _, err := client.dialer.Dial(urlString, http.Header{"Authorization": []string{authorizationHeader}})
     return connection, err
 }
 
@@ -99,20 +103,21 @@ func (client *client) awaitMessages(connection *WebsocketConn, out *chan string,
     }
 }
 
-func (client *client) handleEvents(connection *WebsocketConn, doneListening *chan struct{}, interrupt *chan os.Signal) error {
+func (client *client) handleEvents(connection *WebsocketConn, doneListening *chan struct{},
+                                   interrupt *chan os.Signal) error {
     for {
         select {
         case <-*doneListening:
             return nil
         case <-*interrupt:
             log.Println("interrupt")
-            err := client.closeConnection(connection, doneListening)
+            err := client.closeConnection(connection)
             return err
         }
     }
 }
 
-func (client *client) closeConnection(connection *WebsocketConn, doneListening *chan struct{}) error {
+func (client *client) closeConnection(connection *WebsocketConn) error {
     conn := *connection
     err := conn.WriteMessage(
         websocket.CloseMessage,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -13,6 +13,7 @@ import (
     "github.com/stretchr/testify/suite"
 
     "github.com/thecoderstudio/apollo-agent/client"
+    "github.com/thecoderstudio/apollo-agent/oauth"
 )
 
 var u = url.URL{Scheme: "ws", Host: "localhost:8000", Path: "/ws"}
@@ -78,10 +79,10 @@ func (suite *ClientTestSuite) TestListenSuccess() {
     mockConn.On("ReadMessage").Return(0, []byte("test message"), nil)
 
     mockDialer := new(DialerMock)
-    mockDialer.On("Dial", u.String(), http.Header(nil)).Return(mockConn, nil, nil)
+    mockDialer.On("Dial", u.String(), http.Header{"Authorization":[]string{" "}}).Return(mockConn, nil, nil)
 
     wsClient := client.Create(mockDialer)
-    out, done, _ := wsClient.Listen(u, &interrupt)
+    out, done, _ := wsClient.Listen(u, oauth.AccessToken{}, &interrupt)
     message := <-out
 
     assert.Equal(suite.T(), message, "test message")
@@ -104,10 +105,10 @@ func (suite *ClientTestSuite) TestCloseConnectionWriteError() {
     mockConn.On("ReadMessage").Return(0, nil, nil)
 
     mockDialer := new(DialerMock)
-    mockDialer.On("Dial", u.String(), http.Header(nil)).Return(mockConn, nil, nil)
+    mockDialer.On("Dial", u.String(), http.Header{"Authorization":[]string{" "}}).Return(mockConn, nil, nil)
 
     wsClient := client.Create(mockDialer)
-    out, done, _ := wsClient.Listen(u, &interrupt)
+    out, done, _ := wsClient.Listen(u, oauth.AccessToken{}, &interrupt)
     <-out
 
     close(interrupt)
@@ -122,10 +123,10 @@ func (suite *ClientTestSuite) TestConnectionError() {
     defer close(interrupt)
 
     mockDialer := new(DialerMock)
-    mockDialer.On("Dial", u.String(), http.Header(nil)).Return(nil, nil, expectedError)
+    mockDialer.On("Dial", u.String(), http.Header{"Authorization":[]string{" "}}).Return(nil, nil, expectedError)
 
     wsClient := client.Create(mockDialer)
-    _, _, errs := wsClient.Listen(u, &interrupt)
+    _, _, errs := wsClient.Listen(u, oauth.AccessToken{}, &interrupt)
     err := <-errs
 
     mockDialer.AssertExpectations(suite.T())
@@ -142,10 +143,10 @@ func (suite *ClientTestSuite) TestReadMessageError() {
     mockConn.On("ReadMessage").Return(0, nil, expectedError)
 
     mockDialer := new(DialerMock)
-    mockDialer.On("Dial", u.String(), http.Header(nil)).Return(mockConn, nil, nil)
+    mockDialer.On("Dial", u.String(), http.Header{"Authorization":[]string{" "}}).Return(mockConn, nil, nil)
 
     wsClient := client.Create(mockDialer)
-    _, done, errs := wsClient.Listen(u, &interrupt)
+    _, done, errs := wsClient.Listen(u, oauth.AccessToken{}, &interrupt)
     err := <-errs
 
     assert.NotNil(suite.T(), <-done)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,7 +4,6 @@ import (
     "errors"
     "net/http"
     "net/url"
-    "os"
     "testing"
 
     "github.com/gorilla/websocket"
@@ -22,12 +21,12 @@ type ConnMock struct {
     mock.Mock
 }
 
-func (mocked ConnMock) Close() error {
+func (mocked *ConnMock) Close() error {
     args := mocked.Called()
     return args.Error(0)
 }
 
-func (mocked ConnMock) ReadMessage() (messageType int, p []byte, err error) {
+func (mocked *ConnMock) ReadMessage() (messageType int, p []byte, err error) {
     args := mocked.Called()
 
     var message []byte
@@ -38,7 +37,7 @@ func (mocked ConnMock) ReadMessage() (messageType int, p []byte, err error) {
     return args.Int(0), message, args.Error(2)
 }
 
-func (mocked ConnMock) WriteMessage(messageType int, data []byte) error {
+func (mocked *ConnMock) WriteMessage(messageType int, data []byte) error {
     args := mocked.Called(messageType, data)
     return args.Error(0)
 }
@@ -47,7 +46,7 @@ type DialerMock struct {
     mock.Mock
 }
 
-func (mocked DialerMock) Dial(urlString string, header http.Header) (client.WebsocketConn, *http.Response, error) {
+func (mocked *DialerMock) Dial(urlString string, header http.Header) (client.WebsocketConn, *http.Response, error) {
     args := mocked.Called(urlString, header)
 
     var connection client.WebsocketConn
@@ -68,7 +67,7 @@ type ClientTestSuite struct {
 }
 
 func (suite *ClientTestSuite) TestListenSuccess() {
-    interrupt := make(chan os.Signal, 1)
+    interrupt := make(chan struct{})
 
     mockConn := new(ConnMock)
     mockConn.On("Close").Return(nil)
@@ -94,7 +93,7 @@ func (suite *ClientTestSuite) TestListenSuccess() {
 
 func (suite *ClientTestSuite) TestCloseConnectionWriteError() {
     expectedError := errors.New("test")
-    interrupt := make(chan os.Signal, 1)
+    interrupt := make(chan struct{})
 
     mockConn := new(ConnMock)
     mockConn.On("Close").Return(nil)
@@ -119,7 +118,7 @@ func (suite *ClientTestSuite) TestCloseConnectionWriteError() {
 
 func (suite *ClientTestSuite) TestConnectionError() {
     expectedError := errors.New("connection error")
-    interrupt := make(chan os.Signal, 1)
+    interrupt := make(chan struct{})
     defer close(interrupt)
 
     mockDialer := new(DialerMock)
@@ -135,7 +134,7 @@ func (suite *ClientTestSuite) TestConnectionError() {
 
 func (suite *ClientTestSuite) TestReadMessageError() {
     expectedError := errors.New("read error")
-    interrupt := make(chan os.Signal, 1)
+    interrupt := make(chan struct{})
     defer close(interrupt)
 
     mockConn := new(ConnMock)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/thecoderstudio/apollo-agent
 go 1.14
 
 require (
-    github.com/gorilla/websocket v1.4.2
-    github.com/stretchr/testify v1.5.1
+	github.com/gorilla/websocket v1.4.2
+	github.com/jessevdk/go-flags v1.4.0
+	github.com/stretchr/testify v1.5.1
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/thecoderstudio/apollo-agent
 go 1.14
 
 require (
-	github.com/gorilla/websocket v1.4.2
-	github.com/jessevdk/go-flags v1.4.0
-	github.com/stretchr/testify v1.5.1
+    github.com/gorilla/websocket v1.4.2
+    github.com/jessevdk/go-flags v1.4.0
+    github.com/stretchr/testify v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
     interrupt := make(chan os.Signal, 1)
     signal.Notify(interrupt, os.Interrupt)
 
-    oauthClient := oauth.OAuthClient{Host: *addr}
+    oauthClient := oauth.Create(*addr)
     oauthClient.GetAccessToken()
 
     u := url.URL{Scheme: "ws", Host: *addr, Path: "/ws"}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
     "os/signal"
 
     "github.com/thecoderstudio/apollo-agent/client"
+    "github.com/thecoderstudio/apollo-agent/oauth"
 )
 
 var addr = flag.String("addr", "", "host address")
@@ -22,6 +23,9 @@ func main() {
 
     interrupt := make(chan os.Signal, 1)
     signal.Notify(interrupt, os.Interrupt)
+
+    oauthClient := oauth.OAuthClient{Host: *addr}
+    oauthClient.GetAccessToken()
 
     u := url.URL{Scheme: "ws", Host: *addr, Path: "/ws"}
     wsClient := client.Create(new(client.DialWrapper))

--- a/main.go
+++ b/main.go
@@ -25,11 +25,12 @@ func main() {
     signal.Notify(interrupt, os.Interrupt)
 
     oauthClient := oauth.Create(*addr)
-    oauthClient.GetAccessToken()
+    newAccessToken := oauthClient.GetContinuousAccessToken()
+    accessToken := <-*newAccessToken
 
     u := url.URL{Scheme: "ws", Host: *addr, Path: "/ws"}
     wsClient := client.Create(new(client.DialWrapper))
-    out, done, errs := wsClient.Listen(u, &interrupt)
+    out, done, errs := wsClient.Listen(u, accessToken, &interrupt)
     for {
         select {
         case msg := <-out:

--- a/main.go
+++ b/main.go
@@ -1,36 +1,39 @@
 package main
 
 import (
-    "flag"
     "log"
     "net/url"
     "os"
     "os/signal"
 
+    "github.com/jessevdk/go-flags"
+
     "github.com/thecoderstudio/apollo-agent/client"
     "github.com/thecoderstudio/apollo-agent/oauth"
 )
 
-var addr = flag.String("addr", "", "host address")
-var agentID = flag.String("agent-id", "", "Apollo agent id")
-var secret = flag.String("secret", "", "Apollo OAuth client secret")
+var opts struct {
+    Host string `short:"h" long:"host" description:"Host address" required:"true"`
+    AgentID string `long:"agent-id" description:"Apollo agent id" required:"true"`
+    Secret string `long:"secret" description:"Apollo OAuth client secret" required:"true"`
+}
 
 func main() {
-    flag.Parse()
     log.SetFlags(0)
-
-    if *addr == "" {
-        log.Fatal("--addr is required, please give a valid host address")
+    _, err := flags.Parse(&opts)
+    if err != nil {
+        panic(err)
     }
+    host := opts.Host
 
     interrupt := make(chan os.Signal, 1)
     signal.Notify(interrupt, os.Interrupt)
 
-    oauthClient := oauth.Create(*addr, *agentID, *secret)
+    oauthClient := oauth.Create(host, opts.AgentID, opts.Secret)
     newAccessToken := oauthClient.GetContinuousAccessToken()
     accessToken := <-*newAccessToken
 
-    u := url.URL{Scheme: "ws", Host: *addr, Path: "/ws"}
+    u := url.URL{Scheme: "ws", Host: host, Path: "/ws"}
     wsClient := client.Create(new(client.DialWrapper))
     out, done, errs := wsClient.Listen(u, accessToken, &interrupt)
     for {

--- a/main.go
+++ b/main.go
@@ -12,6 +12,8 @@ import (
 )
 
 var addr = flag.String("addr", "", "host address")
+var agentID = flag.String("agent-id", "", "Apollo agent id")
+var secret = flag.String("secret", "", "Apollo OAuth client secret")
 
 func main() {
     flag.Parse()
@@ -24,7 +26,7 @@ func main() {
     interrupt := make(chan os.Signal, 1)
     signal.Notify(interrupt, os.Interrupt)
 
-    oauthClient := oauth.Create(*addr)
+    oauthClient := oauth.Create(*addr, *agentID, *secret)
     newAccessToken := oauthClient.GetContinuousAccessToken()
     accessToken := <-*newAccessToken
 

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -35,7 +35,7 @@ func (client *OAuthClient) GetAccessToken() AccessToken {
         panic(err)
     }
 
-    req.Header.Add("authorization", auth)
+    req.Header.Add("Authorization", auth)
     req.Header.Add("Content-Type", "application/json")
 
     resp, err := client.Client.Do(req)

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -6,6 +6,7 @@ import (
     "encoding/json"
 	"fmt"
     "time"
+    "log"
 	"io/ioutil"
     "net/http"
     "net/url"
@@ -22,6 +23,8 @@ type AccessToken struct {
 type Client struct {
     Host string
     Client http.Client
+    AgentID string
+    ClientSecret string
 }
 
 
@@ -31,14 +34,12 @@ func (client *Client) GetAccessToken() AccessToken {
     values := map[string]string{"grant_type": "client_credentials"}
     jsonValue, _ := json.Marshal(values)
 
-    // Fake creds
-    creds := "73d711e0-923d-42a7-9857-5f3d67d88370:8f5712b5efc5fd711abb3d16925e25a41561e92a041ab4956083d2cfdb5f442e"
-
+    creds := fmt.Sprintf("%s:%s", client.AgentID, client.ClientSecret)
     auth := fmt.Sprintf("Basic %s", b64.StdEncoding.EncodeToString([]byte(creds)))
 
     req, err := http.NewRequest("POST", url.String(), bytes.NewBuffer(jsonValue))
     if err != nil {
-        panic(err)
+        log.Fatal(err)
     }
 
     req.Header.Add("Authorization", auth)
@@ -46,7 +47,7 @@ func (client *Client) GetAccessToken() AccessToken {
 
     resp, err := client.Client.Do(req)
     if err != nil {
-        panic(err)
+        log.Fatal(err)
     }
 
     defer resp.Body.Close()
@@ -75,6 +76,11 @@ func (client *Client) keepTokenAlive(accessTokenChannel *chan AccessToken, offse
 }
 
 // Create is a factory to create a properly instantiated Client
-func Create(host string) Client {
-    return Client{Host: host, Client: http.Client{}}
+func Create(host string, agentID string, clientSecret string) Client {
+    return Client{
+        Host: host,
+        Client: http.Client{},
+        AgentID: agentID,
+        ClientSecret: clientSecret,
+    }
 }

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -59,18 +59,18 @@ func (client *Client) GetAccessToken() AccessToken {
 }
 
 // GetContinuousAccessToken returns a channel over which an AccessToken will be sent.
-// When the AccessToken is close to expiration a new one will get requested and sent.
+// When the AccessToken is 2 minutes to expiration a new one will get requested and sent.
 func (client *Client) GetContinuousAccessToken() *chan AccessToken {
     channel := make(chan AccessToken)
-    go client.keepTokenAlive(&channel)
+    go client.keepTokenAlive(&channel, 120)
     return &channel
 }
 
-func (client *Client) keepTokenAlive(accessTokenChannel *chan AccessToken) {
+func (client *Client) keepTokenAlive(accessTokenChannel *chan AccessToken, offsetInSeconds int) {
     for {
         newAccessToken := client.GetAccessToken()
         *accessTokenChannel <- newAccessToken
-        time.Sleep(time.Duration(newAccessToken.ExpiresIn - 120) * time.Second)
+        time.Sleep(time.Duration(newAccessToken.ExpiresIn - offsetInSeconds) * time.Second)
     }
 }
 

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -10,12 +10,18 @@ import (
     "net/url"
 )
 
+type AccessToken struct {
+    AccessToken string `json:"access_token"`
+    ExpiresIn   int `json:"expires_in"`
+    TokenType   string `json:"token_type"`
+}
+
 type OAuthClient struct {
     Host string
     Client http.Client
 }
 
-func (client *OAuthClient) GetAccessToken() string {
+func (client *OAuthClient) GetAccessToken() AccessToken {
     url := url.URL{Scheme: "http", Host: client.Host, Path: "/oauth/token"}
     values := map[string]string{"grant_type": "client_credentials"}
     jsonValue, _ := json.Marshal(values)
@@ -41,8 +47,9 @@ func (client *OAuthClient) GetAccessToken() string {
 
     fmt.Println("response Status:", resp.Status)
     body, _ := ioutil.ReadAll(resp.Body)
-    fmt.Println("response Body:", string(body))
-    return string(body)
+    accessToken := AccessToken{}
+    json.Unmarshal(body, &accessToken)
+    return accessToken
 }
 
 func Create(host string) OAuthClient {

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -1,0 +1,31 @@
+package oauth
+
+import (
+    "bytes"
+    "encoding/json"
+	"fmt"
+	"io/ioutil"
+    "net/http"
+    "net/url"
+)
+
+type OAuthClient struct {
+    Host string
+}
+
+func (client *OAuthClient) GetAccessToken() {
+    url := url.URL{Scheme: "http", Host: client.Host, Path: "/oauth/token"}
+    values := map[string]string{"grant_type": "client_credentials"}
+    jsonValue, _ := json.Marshal(values)
+
+    resp, err := http.Post(url.String(), "application/json", bytes.NewBuffer(jsonValue))
+	if err != nil {
+        panic(err)
+    }
+
+	defer resp.Body.Close()
+
+    fmt.Println("response Status:", resp.Status)
+    body, _ := ioutil.ReadAll(resp.Body)
+    fmt.Println("response Body:", string(body))
+}

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -26,6 +26,7 @@ func (client *OAuthClient) GetAccessToken() AccessToken {
     values := map[string]string{"grant_type": "client_credentials"}
     jsonValue, _ := json.Marshal(values)
 
+    // Fake creds
     creds := "73d711e0-923d-42a7-9857-5f3d67d88370:8f5712b5efc5fd711abb3d16925e25a41561e92a041ab4956083d2cfdb5f442e"
 
     auth := fmt.Sprintf("Basic %s", b64.StdEncoding.EncodeToString([]byte(creds)))
@@ -43,13 +44,21 @@ func (client *OAuthClient) GetAccessToken() AccessToken {
         panic(err)
     }
 
-	defer resp.Body.Close()
+    defer resp.Body.Close()
 
     fmt.Println("response Status:", resp.Status)
     body, _ := ioutil.ReadAll(resp.Body)
     accessToken := AccessToken{}
     json.Unmarshal(body, &accessToken)
     return accessToken
+}
+
+func (client *OAuthClient) GetContinuousAccessToken() *chan AccessToken {
+    channel := make(chan AccessToken)
+    go func() {
+        channel <- client.GetAccessToken()
+    }()
+    return &channel
 }
 
 func Create(host string) OAuthClient {

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -49,7 +49,6 @@ func (client *Client) GetAccessToken() (AccessToken, error) {
 
     defer resp.Body.Close()
 
-    fmt.Println("response Status:", resp.Status)
     body, _ := ioutil.ReadAll(resp.Body)
     accessToken = AccessToken{}
     json.Unmarshal(body, &accessToken)

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -4,9 +4,9 @@ import (
     "bytes"
     b64 "encoding/base64"
     "encoding/json"
-	"fmt"
+    "fmt"
     "time"
-	"io/ioutil"
+    "io/ioutil"
     "net/http"
     "net/url"
 )

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -37,10 +37,7 @@ func (client *Client) GetAccessToken() (AccessToken, error) {
     auth := fmt.Sprintf("Basic %s", b64.StdEncoding.EncodeToString([]byte(creds)))
     var accessToken AccessToken
 
-    req, err := http.NewRequest("POST", url.String(), bytes.NewBuffer(jsonValue))
-    if err != nil {
-        return accessToken, err
-    }
+    req, _ := http.NewRequest("POST", url.String(), bytes.NewBuffer(jsonValue))
 
     req.Header.Add("Authorization", auth)
     req.Header.Add("Content-Type", "application/json")

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
     "bytes"
+    b64 "encoding/base64"
     "encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,6 +12,7 @@ import (
 
 type OAuthClient struct {
     Host string
+    Client http.Client
 }
 
 func (client *OAuthClient) GetAccessToken() {
@@ -18,7 +20,15 @@ func (client *OAuthClient) GetAccessToken() {
     values := map[string]string{"grant_type": "client_credentials"}
     jsonValue, _ := json.Marshal(values)
 
-    resp, err := http.Post(url.String(), "application/json", bytes.NewBuffer(jsonValue))
+    creds := "73d711e0-923d-42a7-9857-5f3d67d88370:8f5712b5efc5fd711abb3d16925e25a41561e92a041ab4956083d2cfdb5f442e"
+
+    auth := fmt.Sprintf("Basic %s", b64.StdEncoding.EncodeToString([]byte(creds)))
+
+    req, _ := http.NewRequest("POST", url.String(), bytes.NewBuffer(jsonValue))
+    req.Header.Add("authorization", auth)
+    req.Header.Add("Content-Type", "application/json")
+
+    resp, err := client.Client.Do(req)
 	if err != nil {
         panic(err)
     }
@@ -28,4 +38,8 @@ func (client *OAuthClient) GetAccessToken() {
     fmt.Println("response Status:", resp.Status)
     body, _ := ioutil.ReadAll(resp.Body)
     fmt.Println("response Body:", string(body))
+}
+
+func Create(host string) OAuthClient {
+    return OAuthClient{Host: host, Client: http.Client{}}
 }

--- a/oauth/oauth.go
+++ b/oauth/oauth.go
@@ -15,7 +15,7 @@ type OAuthClient struct {
     Client http.Client
 }
 
-func (client *OAuthClient) GetAccessToken() {
+func (client *OAuthClient) GetAccessToken() string {
     url := url.URL{Scheme: "http", Host: client.Host, Path: "/oauth/token"}
     values := map[string]string{"grant_type": "client_credentials"}
     jsonValue, _ := json.Marshal(values)
@@ -24,12 +24,16 @@ func (client *OAuthClient) GetAccessToken() {
 
     auth := fmt.Sprintf("Basic %s", b64.StdEncoding.EncodeToString([]byte(creds)))
 
-    req, _ := http.NewRequest("POST", url.String(), bytes.NewBuffer(jsonValue))
+    req, err := http.NewRequest("POST", url.String(), bytes.NewBuffer(jsonValue))
+    if err != nil {
+        panic(err)
+    }
+
     req.Header.Add("authorization", auth)
     req.Header.Add("Content-Type", "application/json")
 
     resp, err := client.Client.Do(req)
-	if err != nil {
+    if err != nil {
         panic(err)
     }
 
@@ -38,6 +42,7 @@ func (client *OAuthClient) GetAccessToken() {
     fmt.Println("response Status:", resp.Status)
     body, _ := ioutil.ReadAll(resp.Body)
     fmt.Println("response Body:", string(body))
+    return string(body)
 }
 
 func Create(host string) OAuthClient {

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -29,7 +29,8 @@ func TestGetAccessTokenMalformedURL(t *testing.T) {
     serverMock := createServerMock(false)
     defer serverMock.Close()
     oauthClient := oauth.Create("fakeurl", "", "")
-    oauthClient.GetAccessToken()
+    _, err := oauthClient.GetAccessToken()
+    assert.Error(t, err, "lookup fakeurl: no such host")
 }
 
 func TestGetContinuousAccessToken(t *testing.T) {
@@ -46,6 +47,15 @@ func TestGetContinuousAccessToken(t *testing.T) {
     assert.NotNil(t, firstAccessToken)
     assert.NotNil(t, secondAccessToken)
     assert.LessOrEqual(t, elapsed.Seconds(), float64(2))
+}
+
+func TestGetContinuousAccessTokenMalformedURL(t *testing.T) {
+    serverMock := createServerMock(false)
+    defer serverMock.Close()
+    oauthClient := oauth.Create("fakeurl", "", "")
+    _, errs := oauthClient.GetContinuousAccessToken()
+    err := <-*errs
+    assert.Error(t, err, "lookup fakeurl: no such host")
 }
 
 func createServerMock(throwErr bool) *httptest.Server {

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -30,6 +30,13 @@ func createServerMock() *httptest.Server {
 }
 
 func authTokenMock(writer http.ResponseWriter, request *http.Request) {
+    if request.Header.Get("Authorization") == "" {
+        errorBody := map[string]string{"detail": "Invalid Authorization header"}
+        errorBodyJson, _ := json.Marshal(errorBody)
+        writer.WriteHeader(http.StatusBadRequest)
+        writer.Write(errorBodyJson)
+    }
+
     accessToken := &oauth.AccessToken{
         AccessToken:    "faketoken",
         ExpiresIn:      3600,

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -17,8 +17,9 @@ func TestGetAccessToken(t *testing.T) {
     serverMock := createServerMock(false)
     defer serverMock.Close()
     oauthClient := oauth.Create(strings.TrimPrefix(serverMock.URL, "http://"), "", "")
-    token := oauthClient.GetAccessToken()
+    token, err := oauthClient.GetAccessToken()
 
+    assert.NoError(t, err)
     assert.Equal(t, token.AccessToken, "faketoken")
     assert.Equal(t, token.ExpiresIn, 121)
     assert.Equal(t, token.TokenType, "Bearer")
@@ -37,7 +38,7 @@ func TestGetContinuousAccessToken(t *testing.T) {
     oauthClient := oauth.Create(strings.TrimPrefix(serverMock.URL, "http://"), "", "")
 
     start := time.Now()
-    tokenChannel := oauthClient.GetContinuousAccessToken()
+    tokenChannel, _ := oauthClient.GetContinuousAccessToken()
     firstAccessToken := <-*tokenChannel
     secondAccessToken := <-*tokenChannel
     elapsed := time.Since(start)

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -1,0 +1,31 @@
+package oauth_test
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+
+    "github.com/thecoderstudio/apollo-agent/oauth"
+)
+
+func TestGetAccessToken(t *testing.T) {
+    serverMock := createServerMock()
+    defer serverMock.Close()
+    oauthClient := oauth.Create(strings.TrimPrefix(serverMock.URL, "http://"))
+    token := oauthClient.GetAccessToken()
+
+    assert.Equal(t, token, "Test")
+}
+
+func createServerMock() *httptest.Server {
+    handler := http.NewServeMux()
+    handler.HandleFunc("/oauth/token", authTokenMock)
+    return httptest.NewServer(handler)
+}
+
+func authTokenMock(writer http.ResponseWriter, request *http.Request) {
+    _, _ = writer.Write([]byte("Test"))
+}

--- a/oauth/oauth_test.go
+++ b/oauth/oauth_test.go
@@ -1,6 +1,7 @@
 package oauth_test
 
 import (
+    "encoding/json"
     "net/http"
     "net/http/httptest"
     "strings"
@@ -17,7 +18,9 @@ func TestGetAccessToken(t *testing.T) {
     oauthClient := oauth.Create(strings.TrimPrefix(serverMock.URL, "http://"))
     token := oauthClient.GetAccessToken()
 
-    assert.Equal(t, token, "Test")
+    assert.Equal(t, token.AccessToken, "faketoken")
+    assert.Equal(t, token.ExpiresIn, 3600)
+    assert.Equal(t, token.TokenType, "Bearer")
 }
 
 func createServerMock() *httptest.Server {
@@ -27,5 +30,12 @@ func createServerMock() *httptest.Server {
 }
 
 func authTokenMock(writer http.ResponseWriter, request *http.Request) {
-    _, _ = writer.Write([]byte("Test"))
+    accessToken := &oauth.AccessToken{
+        AccessToken:    "faketoken",
+        ExpiresIn:      3600,
+        TokenType:      "Bearer",
+    }
+
+    accessTokenJson, _ := json.Marshal(accessToken)
+    _, _ = writer.Write(accessTokenJson)
 }


### PR DESCRIPTION
## Code R Ticket
_Please provide a link to the Code R Jira ticket if applicable_

<https://partypeak.atlassian.net/browse/AP-27>

## Description
Adds the ability to the client to authenticate itself to the Apollo API using OAuth. The token will be automatically renewed and the client will reconnect before expiration.

## Dependencies
_Are there any dependencies in relation to pull requests in other Apollo repositories? If so please provide links to these pull requests_

*

## Additional notes
Exact usage will be documented in https://partypeak.atlassian.net/browse/AP-22.
