### PR TITLE
AP-33 web terminal emulator

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,12 @@ func connect(accessTokenChan *chan oauth.AccessToken, initialToken oauth.AccessT
 			out, done, errs = wsClient.Listen(u, newAccessToken, &in, &interrupt)
 			close(previousInterrupt)
 		case message := <-out:
-			go ptyManager.Execute(message)
+            // TODO create top management struct
+            if message.Message == "new connection" {
+                ptyManager.CreateNewSession(message.ConnectionID)
+            } else {
+                go ptyManager.Execute(message)
+            }
 		case err := <-errs:
 			log.Println(err)
 		case <-*interruptSignal:

--- a/main.go
+++ b/main.go
@@ -74,9 +74,9 @@ func connect(accessTokenChan *chan oauth.AccessToken, initialToken oauth.AccessT
 			done = wsClient.Listen(u, newAccessToken, &in, &interrupt)
 			close(previousInterrupt)
 		case shellIO := <-wsClient.Out():
-            go ptyManager.Execute(shellIO)
-        case command := <-wsClient.Commands():
-            ptyManager.ExecutePredefinedCommand(command)
+			go ptyManager.Execute(shellIO)
+		case command := <-wsClient.Commands():
+			ptyManager.ExecutePredefinedCommand(command)
 		case err := <-wsClient.Errs():
 			log.Println(err)
 		case <-*interruptSignal:

--- a/main.go
+++ b/main.go
@@ -76,10 +76,7 @@ func connect(accessTokenChan *chan oauth.AccessToken, initialToken oauth.AccessT
 		case shellComm := <-out:
             go ptyManager.Execute(shellComm)
         case command := <-commands:
-            // TODO create top management struct, maybe just the PTY manager.
-            if command.Command == "new connection" {
-                ptyManager.CreateNewSession(command.ConnectionID)
-            }
+            ptyManager.ExecutePredefinedCommand(command)
 		case err := <-errs:
 			log.Println(err)
 		case <-*interruptSignal:

--- a/main.go
+++ b/main.go
@@ -73,8 +73,8 @@ func connect(accessTokenChan *chan oauth.AccessToken, initialToken oauth.AccessT
 			interrupt = make(chan struct{})
 			done = wsClient.Listen(u, newAccessToken, &in, &interrupt)
 			close(previousInterrupt)
-		case shellComm := <-wsClient.Out():
-            go ptyManager.Execute(shellComm)
+		case shellIO := <-wsClient.Out():
+            go ptyManager.Execute(shellIO)
         case command := <-wsClient.Commands():
             ptyManager.ExecutePredefinedCommand(command)
 		case err := <-wsClient.Errs():

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func connect(accessTokenChan *chan oauth.AccessToken, initialToken oauth.AccessT
 			out, done, errs = wsClient.Listen(u, newAccessToken, &in, &interrupt)
 			close(previousInterrupt)
 		case message := <-out:
-			ptyManager.Execute(message)
+			go ptyManager.Execute(message)
 		case err := <-errs:
 			log.Println(err)
 		case <-*interruptSignal:

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func connect(accessTokenChan *chan oauth.AccessToken, initialToken oauth.AccessT
 	wsClient := websocket.CreateClient(new(websocket.DialWrapper))
 
 	interrupt := make(chan struct{})
-	in := make(chan websocket.ShellCommunication)
+	in := make(chan websocket.ShellIO)
 	defer close(in)
 
 	ptyManager := pty.CreateManager(&in)

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -5,22 +5,22 @@ import (
 )
 
 // Manager helps managing multiple PTY sessions by finding or creating the
-// correct session based on Message.ConnectionID and handling execution.
+// correct session based on ShellCommunication.ConnectionID and handling execution.
 type Manager struct {
 	sessions map[string]*Session
-	out      *chan websocket.Message
+	out      *chan websocket.ShellCommunication
 }
 
 // Execute executes the given command in a PTY session, reusing a session if
 // if already exists.
-func (manager *Manager) Execute(message websocket.Message) {
-	pty := manager.sessions[message.ConnectionID]
+func (manager *Manager) Execute(shellComm websocket.ShellCommunication) {
+	pty := manager.sessions[shellComm.ConnectionID]
 
 	if pty == nil {
-        pty = manager.CreateNewSession(message.ConnectionID)
+        pty = manager.CreateNewSession(shellComm.ConnectionID)
 	}
 
-	go pty.Execute(message.Message)
+	go pty.Execute(shellComm.Message)
 }
 
 // CreateNewSession creates a new PTY session for the given ID,
@@ -33,7 +33,7 @@ func (manager *Manager) CreateNewSession(sessionID string) *Session {
     return pty
 }
 
-func (manager *Manager) writeOutput(in *<-chan websocket.Message) {
+func (manager *Manager) writeOutput(in *<-chan websocket.ShellCommunication) {
 	for {
 		message := <-*in
 		*manager.out <- message
@@ -48,7 +48,7 @@ func (manager *Manager) Close() {
 }
 
 // CreateManager creates a Manager with the required out channel.
-func CreateManager(out *chan websocket.Message) Manager {
+func CreateManager(out *chan websocket.ShellCommunication) Manager {
 	return Manager{
 		sessions: map[string]*Session{},
 		out:      out,

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -16,28 +16,30 @@ type Manager struct {
 
 // ExecutePredefinedCommand executes the pre-defined command if it exists.
 func (manager *Manager) ExecutePredefinedCommand(command websocket.Command) {
-    // TODO deal with default
-    switch command.Command {
-    case NewConnection:
-        manager.CreateNewSession(command.ConnectionID)
+    if command.Command == NewConnection {
+        manager.createNewSession(command.ConnectionID)
     }
 }
 
-// Execute executes the given shell command in a PTY session, reusing a session if
+// Execute send the given input to the PTY session, reusing a session if
 // if already exists.
 func (manager *Manager) Execute(shellIO websocket.ShellIO) {
-	pty := manager.sessions[shellIO.ConnectionID]
+	pty := manager.GetSession(shellIO.ConnectionID)
 
 	if pty == nil {
-        pty = manager.CreateNewSession(shellIO.ConnectionID)
+        pty = manager.createNewSession(shellIO.ConnectionID)
 	}
 
 	go pty.Execute(shellIO.Message)
 }
 
-// CreateNewSession creates a new PTY session for the given ID,
-// overwriting the existing session for this ID if present.
-func (manager *Manager) CreateNewSession(sessionID string) *Session {
+// GetSession returns the session for the given ID or nil if no such
+// session exists.
+func (manager *Manager) GetSession(sessionID string) *Session {
+    return manager.sessions[sessionID]
+}
+
+func (manager *Manager) createNewSession(sessionID string) *Session {
     pty := CreateSession(sessionID)
     manager.sessions[sessionID] = pty
     out := pty.Out()

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -4,6 +4,9 @@ import (
 	"github.com/thecoderstudio/apollo-agent/websocket"
 )
 
+// NewConnection command to open a new connection and PTY session
+const NewConnection = "new connection"
+
 // Manager helps managing multiple PTY sessions by finding or creating the
 // correct session based on ShellCommunication.ConnectionID and handling execution.
 type Manager struct {
@@ -11,7 +14,16 @@ type Manager struct {
 	out      *chan websocket.ShellCommunication
 }
 
-// Execute executes the given command in a PTY session, reusing a session if
+// ExecutePredefinedCommand executes the pre-defined command if it exists.
+func (manager *Manager) ExecutePredefinedCommand(command websocket.Command) {
+    // TODO deal with default
+    switch command.Command {
+    case NewConnection:
+        manager.CreateNewSession(command.ConnectionID)
+    }
+}
+
+// Execute executes the given shell command in a PTY session, reusing a session if
 // if already exists.
 func (manager *Manager) Execute(shellComm websocket.ShellCommunication) {
 	pty := manager.sessions[shellComm.ConnectionID]

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -16,9 +16,9 @@ type Manager struct {
 
 // ExecutePredefinedCommand executes the pre-defined command if it exists.
 func (manager *Manager) ExecutePredefinedCommand(command websocket.Command) {
-    if command.Command == NewConnection {
-        manager.CreateNewSession(command.ConnectionID)
-    }
+	if command.Command == NewConnection {
+		manager.CreateNewSession(command.ConnectionID)
+	}
 }
 
 // Execute send the given input to the PTY session, reusing a session if
@@ -27,7 +27,7 @@ func (manager *Manager) Execute(shellIO websocket.ShellIO) {
 	pty := manager.GetSession(shellIO.ConnectionID)
 
 	if pty == nil {
-        pty = manager.CreateNewSession(shellIO.ConnectionID)
+		pty = manager.CreateNewSession(shellIO.ConnectionID)
 	}
 
 	go pty.Execute(shellIO.Message)
@@ -36,17 +36,17 @@ func (manager *Manager) Execute(shellIO websocket.ShellIO) {
 // GetSession returns the session for the given ID or nil if no such
 // session exists.
 func (manager *Manager) GetSession(sessionID string) *Session {
-    return manager.sessions[sessionID]
+	return manager.sessions[sessionID]
 }
 
 // CreateNewSession creates a new PTY session for the given ID,
 // overwriting the existing session for this ID if present.
 func (manager *Manager) CreateNewSession(sessionID string) *Session {
-    pty := CreateSession(sessionID)
-    manager.sessions[sessionID] = pty
-    out := pty.Out()
-    go manager.writeOutput(&out)
-    return pty
+	pty := CreateSession(sessionID)
+	manager.sessions[sessionID] = pty
+	out := pty.Out()
+	go manager.writeOutput(&out)
+	return pty
 }
 
 func (manager *Manager) writeOutput(in *<-chan websocket.ShellIO) {

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -25,14 +25,14 @@ func (manager *Manager) ExecutePredefinedCommand(command websocket.Command) {
 
 // Execute executes the given shell command in a PTY session, reusing a session if
 // if already exists.
-func (manager *Manager) Execute(shellComm websocket.ShellIO) {
-	pty := manager.sessions[shellComm.ConnectionID]
+func (manager *Manager) Execute(shellIO websocket.ShellIO) {
+	pty := manager.sessions[shellIO.ConnectionID]
 
 	if pty == nil {
-        pty = manager.CreateNewSession(shellComm.ConnectionID)
+        pty = manager.CreateNewSession(shellIO.ConnectionID)
 	}
 
-	go pty.Execute(shellComm.Message)
+	go pty.Execute(shellIO.Message)
 }
 
 // CreateNewSession creates a new PTY session for the given ID,

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -8,10 +8,10 @@ import (
 const NewConnection = "new connection"
 
 // Manager helps managing multiple PTY sessions by finding or creating the
-// correct session based on ShellCommunication.ConnectionID and handling execution.
+// correct session based on ShellIO.ConnectionID and handling execution.
 type Manager struct {
 	sessions map[string]*Session
-	out      *chan websocket.ShellCommunication
+	out      *chan websocket.ShellIO
 }
 
 // ExecutePredefinedCommand executes the pre-defined command if it exists.
@@ -25,7 +25,7 @@ func (manager *Manager) ExecutePredefinedCommand(command websocket.Command) {
 
 // Execute executes the given shell command in a PTY session, reusing a session if
 // if already exists.
-func (manager *Manager) Execute(shellComm websocket.ShellCommunication) {
+func (manager *Manager) Execute(shellComm websocket.ShellIO) {
 	pty := manager.sessions[shellComm.ConnectionID]
 
 	if pty == nil {
@@ -45,7 +45,7 @@ func (manager *Manager) CreateNewSession(sessionID string) *Session {
     return pty
 }
 
-func (manager *Manager) writeOutput(in *<-chan websocket.ShellCommunication) {
+func (manager *Manager) writeOutput(in *<-chan websocket.ShellIO) {
 	for {
 		message := <-*in
 		*manager.out <- message
@@ -60,7 +60,7 @@ func (manager *Manager) Close() {
 }
 
 // CreateManager creates a Manager with the required out channel.
-func CreateManager(out *chan websocket.ShellCommunication) Manager {
+func CreateManager(out *chan websocket.ShellIO) Manager {
 	return Manager{
 		sessions: map[string]*Session{},
 		out:      out,

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -23,7 +23,7 @@ func (manager *Manager) Execute(message websocket.Message) {
 		go manager.writeOutput(&out)
 	}
 
-	pty.Execute(message.Message)
+	go pty.Execute(message.Message)
 }
 
 func (manager *Manager) writeOutput(in *<-chan websocket.Message) {

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -17,13 +17,20 @@ func (manager *Manager) Execute(message websocket.Message) {
 	pty := manager.sessions[message.ConnectionID]
 
 	if pty == nil {
-		pty = CreateSession(message.ConnectionID)
-		manager.sessions[message.ConnectionID] = pty
-		out := pty.Out()
-		go manager.writeOutput(&out)
+        pty = manager.CreateNewSession(message.ConnectionID)
 	}
 
 	go pty.Execute(message.Message)
+}
+
+// CreateNewSession creates a new PTY session for the given ID,
+// overwriting the existing session for this ID if present.
+func (manager *Manager) CreateNewSession(sessionID string) *Session {
+    pty := CreateSession(sessionID)
+    manager.sessions[sessionID] = pty
+    out := pty.Out()
+    go manager.writeOutput(&out)
+    return pty
 }
 
 func (manager *Manager) writeOutput(in *<-chan websocket.Message) {

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -17,7 +17,7 @@ type Manager struct {
 // ExecutePredefinedCommand executes the pre-defined command if it exists.
 func (manager *Manager) ExecutePredefinedCommand(command websocket.Command) {
     if command.Command == NewConnection {
-        manager.createNewSession(command.ConnectionID)
+        manager.CreateNewSession(command.ConnectionID)
     }
 }
 
@@ -27,7 +27,7 @@ func (manager *Manager) Execute(shellIO websocket.ShellIO) {
 	pty := manager.GetSession(shellIO.ConnectionID)
 
 	if pty == nil {
-        pty = manager.createNewSession(shellIO.ConnectionID)
+        pty = manager.CreateNewSession(shellIO.ConnectionID)
 	}
 
 	go pty.Execute(shellIO.Message)
@@ -39,7 +39,9 @@ func (manager *Manager) GetSession(sessionID string) *Session {
     return manager.sessions[sessionID]
 }
 
-func (manager *Manager) createNewSession(sessionID string) *Session {
+// CreateNewSession creates a new PTY session for the given ID,
+// overwriting the existing session for this ID if present.
+func (manager *Manager) CreateNewSession(sessionID string) *Session {
     pty := CreateSession(sessionID)
     manager.sessions[sessionID] = pty
     out := pty.Out()

--- a/pty/manager_test.go
+++ b/pty/manager_test.go
@@ -41,7 +41,6 @@ func TestGetSession(t *testing.T) {
 	assert.Equal(t, manager.GetSession("test"), session)
 
 	manager.Close()
-
 }
 
 func TestGetSessionNotFound(t *testing.T) {

--- a/pty/manager_test.go
+++ b/pty/manager_test.go
@@ -32,6 +32,32 @@ func TestNewConnectionCommand(t *testing.T) {
     manager.Close()
 }
 
+func TestGetSession(t *testing.T) {
+    out := make(chan websocket.ShellIO)
+	manager := pty.CreateManager(&out)
+
+    session := manager.CreateNewSession("test")
+
+    assert.Equal(t, manager.GetSession("test"), session)
+
+    manager.Close()
+
+}
+
+func TestGetSessionNotFound(t *testing.T) {
+    out := make(chan websocket.ShellIO)
+	manager := pty.CreateManager(&out)
+
+    assert.Nil(t, manager.GetSession("test"))
+}
+
+func TestCreateNewSession(t *testing.T) {
+    out := make(chan websocket.ShellIO)
+	manager := pty.CreateManager(&out)
+
+    assert.NotNil(t, manager.CreateNewSession("test"))
+}
+
 func TestManagerExecute(t *testing.T) {
 	out := make(chan websocket.ShellIO)
 	manager := pty.CreateManager(&out)

--- a/pty/manager_test.go
+++ b/pty/manager_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCreateManager(t *testing.T) {
-	out := make(chan websocket.Message)
+	out := make(chan websocket.ShellCommunication)
 	manager := pty.CreateManager(&out)
 
 	assert.NotNil(t, manager)
@@ -19,16 +19,16 @@ func TestCreateManager(t *testing.T) {
 }
 
 func TestManagerExecute(t *testing.T) {
-	out := make(chan websocket.Message)
+	out := make(chan websocket.ShellCommunication)
 	manager := pty.CreateManager(&out)
 
-	manager.Execute(websocket.Message{
+	manager.Execute(websocket.ShellCommunication{
 		ConnectionID: "test",
 		Message:      "echo 1",
 	})
 	first := <-out
 
-	manager.Execute(websocket.Message{
+	manager.Execute(websocket.ShellCommunication{
 		ConnectionID: "test",
 		Message:      "echo 2",
 	})

--- a/pty/manager_test.go
+++ b/pty/manager_test.go
@@ -19,43 +19,43 @@ func TestCreateManager(t *testing.T) {
 }
 
 func TestNewConnectionCommand(t *testing.T) {
-    out := make(chan websocket.ShellIO)
+	out := make(chan websocket.ShellIO)
 	manager := pty.CreateManager(&out)
 
-    manager.ExecutePredefinedCommand(websocket.Command{
-        ConnectionID:   "test",
-        Command:        pty.NewConnection,
-    })
+	manager.ExecutePredefinedCommand(websocket.Command{
+		ConnectionID: "test",
+		Command:      pty.NewConnection,
+	})
 
-    assert.NotNil(t, manager.GetSession("test"))
+	assert.NotNil(t, manager.GetSession("test"))
 
-    manager.Close()
+	manager.Close()
 }
 
 func TestGetSession(t *testing.T) {
-    out := make(chan websocket.ShellIO)
+	out := make(chan websocket.ShellIO)
 	manager := pty.CreateManager(&out)
 
-    session := manager.CreateNewSession("test")
+	session := manager.CreateNewSession("test")
 
-    assert.Equal(t, manager.GetSession("test"), session)
+	assert.Equal(t, manager.GetSession("test"), session)
 
-    manager.Close()
+	manager.Close()
 
 }
 
 func TestGetSessionNotFound(t *testing.T) {
-    out := make(chan websocket.ShellIO)
+	out := make(chan websocket.ShellIO)
 	manager := pty.CreateManager(&out)
 
-    assert.Nil(t, manager.GetSession("test"))
+	assert.Nil(t, manager.GetSession("test"))
 }
 
 func TestCreateNewSession(t *testing.T) {
-    out := make(chan websocket.ShellIO)
+	out := make(chan websocket.ShellIO)
 	manager := pty.CreateManager(&out)
 
-    assert.NotNil(t, manager.CreateNewSession("test"))
+	assert.NotNil(t, manager.CreateNewSession("test"))
 }
 
 func TestManagerExecute(t *testing.T) {

--- a/pty/manager_test.go
+++ b/pty/manager_test.go
@@ -18,6 +18,20 @@ func TestCreateManager(t *testing.T) {
 	manager.Close()
 }
 
+func TestNewConnectionCommand(t *testing.T) {
+    out := make(chan websocket.ShellIO)
+	manager := pty.CreateManager(&out)
+
+    manager.ExecutePredefinedCommand(websocket.Command{
+        ConnectionID:   "test",
+        Command:        pty.NewConnection,
+    })
+
+    assert.NotNil(t, manager.GetSession("test"))
+
+    manager.Close()
+}
+
 func TestManagerExecute(t *testing.T) {
 	out := make(chan websocket.ShellIO)
 	manager := pty.CreateManager(&out)

--- a/pty/manager_test.go
+++ b/pty/manager_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCreateManager(t *testing.T) {
-	out := make(chan websocket.ShellCommunication)
+	out := make(chan websocket.ShellIO)
 	manager := pty.CreateManager(&out)
 
 	assert.NotNil(t, manager)
@@ -19,16 +19,16 @@ func TestCreateManager(t *testing.T) {
 }
 
 func TestManagerExecute(t *testing.T) {
-	out := make(chan websocket.ShellCommunication)
+	out := make(chan websocket.ShellIO)
 	manager := pty.CreateManager(&out)
 
-	manager.Execute(websocket.ShellCommunication{
+	manager.Execute(websocket.ShellIO{
 		ConnectionID: "test",
 		Message:      "echo 1",
 	})
 	first := <-out
 
-	manager.Execute(websocket.ShellCommunication{
+	manager.Execute(websocket.ShellIO{
 		ConnectionID: "test",
 		Message:      "echo 2",
 	})

--- a/pty/session.go
+++ b/pty/session.go
@@ -42,8 +42,9 @@ func (ptySession *Session) Execute(toBeExecuted string) error {
 		return err
 	}
 
-	if ptySession.session == nil {
+	if toBeExecuted == "new connection" {
 		err = ptySession.createNewSession()
+        return err
 	}
 	_, err = ptySession.session.Write([]byte(toBeExecuted))
 	return err

--- a/pty/session.go
+++ b/pty/session.go
@@ -88,6 +88,6 @@ func CreateSession(sessionID string) *Session {
 		out:       &out,
 		closed:    false,
 	}
-    ptySession.createNewSession()
+	ptySession.createNewSession()
 	return &ptySession
 }

--- a/pty/session.go
+++ b/pty/session.go
@@ -16,7 +16,7 @@ import (
 type Session struct {
 	SessionID string
 	session   *os.File
-	out       *chan websocket.ShellCommunication
+	out       *chan websocket.ShellIO
 	closed    bool
 }
 
@@ -27,7 +27,7 @@ func (ptySession *Session) Session() *os.File {
 
 // Out returns a read-only channel used for communicating output to command
 // execution in the PTY.
-func (ptySession *Session) Out() <-chan websocket.ShellCommunication {
+func (ptySession *Session) Out() <-chan websocket.ShellIO {
 	return *ptySession.out
 }
 
@@ -62,7 +62,7 @@ func (ptySession *Session) listen(session *os.File) {
 		buf := make([]byte, 512)
 		session.Read(buf)
 
-		outComm := websocket.ShellCommunication{
+		outComm := websocket.ShellIO{
 			ConnectionID: ptySession.SessionID,
 			Message:      string(buf),
 		}
@@ -85,7 +85,7 @@ func (ptySession *Session) Close() {
 
 // CreateSession creates a new Session injected with the given sessionID and defaults.
 func CreateSession(sessionID string) *Session {
-	out := make(chan websocket.ShellCommunication)
+	out := make(chan websocket.ShellIO)
 	ptySession := Session{
 		SessionID: sessionID,
 		out:       &out,

--- a/pty/session.go
+++ b/pty/session.go
@@ -16,7 +16,7 @@ import (
 type Session struct {
 	SessionID string
 	session   *os.File
-	out       *chan websocket.Message
+	out       *chan websocket.ShellCommunication
 	closed    bool
 }
 
@@ -27,7 +27,7 @@ func (ptySession *Session) Session() *os.File {
 
 // Out returns a read-only channel used for communicating output to command
 // execution in the PTY.
-func (ptySession *Session) Out() <-chan websocket.Message {
+func (ptySession *Session) Out() <-chan websocket.ShellCommunication {
 	return *ptySession.out
 }
 
@@ -62,14 +62,14 @@ func (ptySession *Session) listen(session *os.File) {
 		buf := make([]byte, 512)
 		session.Read(buf)
 
-		outMessage := websocket.Message{
+		outComm := websocket.ShellCommunication{
 			ConnectionID: ptySession.SessionID,
 			Message:      string(buf),
 		}
-        log.Println(outMessage.ConnectionID)
-        log.Println(outMessage.Message)
+        log.Println(outComm.ConnectionID)
+        log.Println(outComm.Message)
 		if !ptySession.closed {
-			*ptySession.out <- outMessage
+			*ptySession.out <- outComm
 		}
 	}
 }
@@ -85,7 +85,7 @@ func (ptySession *Session) Close() {
 
 // CreateSession creates a new Session injected with the given sessionID and defaults.
 func CreateSession(sessionID string) *Session {
-	out := make(chan websocket.Message)
+	out := make(chan websocket.ShellCommunication)
 	ptySession := Session{
 		SessionID: sessionID,
 		out:       &out,

--- a/pty/session.go
+++ b/pty/session.go
@@ -2,6 +2,7 @@ package pty
 
 import (
 	"errors"
+    "log"
 	"os"
 	"os/exec"
 
@@ -42,10 +43,6 @@ func (ptySession *Session) Execute(toBeExecuted string) error {
 		return err
 	}
 
-	if toBeExecuted == "new connection" {
-		err = ptySession.createNewSession()
-        return err
-	}
 	_, err = ptySession.session.Write([]byte(toBeExecuted))
 	return err
 }
@@ -69,6 +66,8 @@ func (ptySession *Session) listen(session *os.File) {
 			ConnectionID: ptySession.SessionID,
 			Message:      string(buf),
 		}
+        log.Println(outMessage.ConnectionID)
+        log.Println(outMessage.Message)
 		if !ptySession.closed {
 			*ptySession.out <- outMessage
 		}
@@ -92,5 +91,6 @@ func CreateSession(sessionID string) *Session {
 		out:       &out,
 		closed:    false,
 	}
+    ptySession.createNewSession()
 	return &ptySession
 }

--- a/pty/session.go
+++ b/pty/session.go
@@ -2,7 +2,6 @@ package pty
 
 import (
 	"errors"
-    "log"
 	"os"
 	"os/exec"
 
@@ -66,8 +65,6 @@ func (ptySession *Session) listen(session *os.File) {
 			ConnectionID: ptySession.SessionID,
 			Message:      string(buf),
 		}
-        log.Println(outComm.ConnectionID)
-        log.Println(outComm.Message)
 		if !ptySession.closed {
 			*ptySession.out <- outComm
 		}

--- a/pty/session_test.go
+++ b/pty/session_test.go
@@ -13,6 +13,7 @@ func TestCreateSession(t *testing.T) {
 	defer pty.Close()
 
 	assert.Equal(t, pty.SessionID, "test")
+	assert.NotNil(t, pty.Session())
 	assert.NotNil(t, pty.Out())
 }
 
@@ -21,7 +22,7 @@ func TestExecuteEmptyCommand(t *testing.T) {
 	defer pty.Close()
 
 	pty.Execute("")
-	assert.Nil(t, pty.Session())
+    assert.Empty(t, pty.Out())
 }
 
 func TestExecute(t *testing.T) {

--- a/pty/session_test.go
+++ b/pty/session_test.go
@@ -22,7 +22,7 @@ func TestExecuteEmptyCommand(t *testing.T) {
 	defer pty.Close()
 
 	pty.Execute("")
-    assert.Empty(t, pty.Out())
+	assert.Empty(t, pty.Out())
 }
 
 func TestExecute(t *testing.T) {

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -104,6 +104,9 @@ func (client *Client) awaitMessages(connection *Connection, out *chan Message, e
 			}
 			message := Message{}
 			json.Unmarshal([]byte(rawMessage), &message)
+            if message.ConnectionID == "" {
+                continue
+            }
 			*out <- message
 		}
 	}

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -137,6 +137,8 @@ func (client *Client) sendOverChannels(rawMessage []byte) {
 
     json.Unmarshal(rawMessage, &shellIO)
     json.Unmarshal(rawMessage, &command)
+    print(command.Command)
+    print(shellIO.Message)
 
     switch {
     case command.Command != "":

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -11,18 +11,6 @@ import (
 	"github.com/thecoderstudio/apollo-agent/oauth"
 )
 
-// ShellIO is used for communicating shell input, output and error streams.
-type ShellIO struct {
-	ConnectionID string `json:"connection_id"`
-	Message      string `json:"message"`
-}
-
-// Command is used to instruct the agent to execute a pre-defined command.
-type Command struct {
-    ConnectionID    string `json:"connection_id"`
-    Command         string `json:"command"`
-}
-
 // Connection specifies the interface for client connection
 type Connection interface {
 	Close() error

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -137,8 +137,6 @@ func (client *Client) sendOverChannels(rawMessage []byte) {
 
     json.Unmarshal(rawMessage, &shellIO)
     json.Unmarshal(rawMessage, &command)
-    print(command.Command)
-    print(shellIO.Message)
 
     switch {
     case command.Command != "":

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -35,34 +35,34 @@ func (wrapper DialWrapper) Dial(urlString string, header http.Header) (Connectio
 
 // Client is used to connect over the WebSocket protocol and receive as well as send messages.
 type Client struct {
-	dialer      Dialer
-    out         chan ShellIO
-    commands    chan Command
-    errs        chan error
+	dialer   Dialer
+	out      chan ShellIO
+	commands chan Command
+	errs     chan error
 }
 
 // Out contains received shell messages.
 func (client *Client) Out() <-chan ShellIO {
-    return client.out
+	return client.out
 }
 
 // Commands contains received pre-defined commands.
 func (client *Client) Commands() <-chan Command {
-    return client.commands
+	return client.commands
 }
 
 // Errs contains any errors that occur.
 func (client *Client) Errs() <-chan error {
-    return client.errs
+	return client.errs
 }
 
 // Listen connects to the given endpoint and handles incoming messages. It's interruptable
 // by closing the interrupt channel. Outgoing communication send through `in` are sent to Apollo.
 func (client *Client) Listen(
-    endpointURL url.URL,
-    accessToken oauth.AccessToken,
+	endpointURL url.URL,
+	accessToken oauth.AccessToken,
 	in *chan ShellIO,
-    interrupt *chan struct{},
+	interrupt *chan struct{},
 ) <-chan struct{} {
 	done := make(chan struct{})
 
@@ -106,7 +106,7 @@ func (client *Client) awaitMessages(connection *Connection, done, doneListening 
 		select {
 		case <-*done:
 			return
-        default:
+		default:
 			_, rawMessage, err := conn.ReadMessage()
 			if err != nil {
 				log.Println("read error:", err)
@@ -114,26 +114,26 @@ func (client *Client) awaitMessages(connection *Connection, done, doneListening 
 				return
 			}
 
-             client.sendOverChannels([]byte(rawMessage))
+			client.sendOverChannels([]byte(rawMessage))
 		}
 	}
 }
 
 func (client *Client) sendOverChannels(rawMessage []byte) {
-    shellIO := ShellIO{}
-    command := Command{}
+	shellIO := ShellIO{}
+	command := Command{}
 
-    json.Unmarshal(rawMessage, &shellIO)
-    json.Unmarshal(rawMessage, &command)
+	json.Unmarshal(rawMessage, &shellIO)
+	json.Unmarshal(rawMessage, &command)
 
-    switch {
-    case command.Command != "":
-        client.commands <- command
-    case shellIO.Message != "":
-        client.out <- shellIO
-    default:
-        log.Println("Message skipped")
-    }
+	switch {
+	case command.Command != "":
+		client.commands <- command
+	case shellIO.Message != "":
+		client.out <- shellIO
+	default:
+		log.Println("Message skipped")
+	}
 }
 
 func (client *Client) handleEvents(connection *Connection, in *chan ShellIO,

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/thecoderstudio/apollo-agent/oauth"
@@ -90,15 +89,13 @@ func (client *Client) createConnection(endpointURL url.URL, accessToken oauth.Ac
 
 func (client *Client) awaitMessages(connection *Connection, out *chan Message, errs *chan error, done, doneListening *chan struct{}) {
 	defer close(*doneListening)
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
 
 	conn := *connection
 	for {
 		select {
 		case <-*done:
 			return
-		case <-ticker.C:
+        default:
 			_, rawMessage, err := conn.ReadMessage()
 			if err != nil {
 				log.Println("read error:", err)

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -132,17 +132,17 @@ func (client *Client) awaitMessages(connection *Connection, done, doneListening 
 }
 
 func (client *Client) sendOverChannels(rawMessage []byte) {
-    shellComm := ShellIO{}
+    shellIO := ShellIO{}
     command := Command{}
 
-    json.Unmarshal(rawMessage, &shellComm)
+    json.Unmarshal(rawMessage, &shellIO)
     json.Unmarshal(rawMessage, &command)
 
     switch {
     case command.Command != "":
         client.commands <- command
-    case shellComm.Message != "":
-        client.out <- shellComm
+    case shellIO.Message != "":
+        client.out <- shellIO
     default:
         log.Println("Message skipped")
     }

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -11,8 +11,8 @@ import (
 	"github.com/thecoderstudio/apollo-agent/oauth"
 )
 
-// ShellCommunication is used for communicating shell input, output and error streams.
-type ShellCommunication struct {
+// ShellIO is used for communicating shell input, output and error streams.
+type ShellIO struct {
 	ConnectionID string `json:"connection_id"`
 	Message      string `json:"message"`
 }
@@ -48,13 +48,13 @@ func (wrapper DialWrapper) Dial(urlString string, header http.Header) (Connectio
 // Client is used to connect over the WebSocket protocol and receive as well as send messages.
 type Client struct {
 	dialer      Dialer
-    out         chan ShellCommunication
+    out         chan ShellIO
     commands    chan Command
     errs        chan error
 }
 
 // Out contains received shell messages.
-func (client *Client) Out() <-chan ShellCommunication {
+func (client *Client) Out() <-chan ShellIO {
     return client.out
 }
 
@@ -73,7 +73,7 @@ func (client *Client) Errs() <-chan error {
 func (client *Client) Listen(
     endpointURL url.URL,
     accessToken oauth.AccessToken,
-	in *chan ShellCommunication,
+	in *chan ShellIO,
     interrupt *chan struct{},
 ) <-chan struct{} {
 	done := make(chan struct{})
@@ -132,7 +132,7 @@ func (client *Client) awaitMessages(connection *Connection, done, doneListening 
 }
 
 func (client *Client) sendOverChannels(rawMessage []byte) {
-    shellComm := ShellCommunication{}
+    shellComm := ShellIO{}
     command := Command{}
 
     json.Unmarshal(rawMessage, &shellComm)
@@ -148,7 +148,7 @@ func (client *Client) sendOverChannels(rawMessage []byte) {
     }
 }
 
-func (client *Client) handleEvents(connection *Connection, in *chan ShellCommunication,
+func (client *Client) handleEvents(connection *Connection, in *chan ShellIO,
 	doneListening *chan struct{},
 	interrupt *chan struct{}) error {
 	for {
@@ -183,7 +183,7 @@ func (client *Client) closeConnection(connection *Connection) error {
 
 // CreateClient is the factory to create a properly instantiated client.
 func CreateClient(dialer Dialer) Client {
-	out := make(chan ShellCommunication)
+	out := make(chan ShellIO)
 	commands := make(chan Command)
 	errs := make(chan error)
 	return Client{dialer, out, commands, errs}

--- a/websocket/client_test.go
+++ b/websocket/client_test.go
@@ -104,7 +104,7 @@ func (suite *ClientTestSuite) TestCloseConnectionWriteError() {
 
 	mockConn := new(ConnMock)
 	mockConn.MockClosed(expectedError)
-	mockConn.On("ReadMessage").Return(0, nil, nil)
+	mockConn.On("ReadMessage").Maybe().Return(0, nil, nil)
 
 	wsClient := createWsClient(mockConn)
 	done := wsClient.Listen(u, oauth.AccessToken{}, &in, &interrupt)

--- a/websocket/client_test.go
+++ b/websocket/client_test.go
@@ -78,7 +78,7 @@ type ClientTestSuite struct {
 
 func (suite *ClientTestSuite) TestListenSuccess() {
 	interrupt := make(chan struct{})
-	in := make(chan websocket.ShellCommunication)
+	in := make(chan websocket.ShellIO)
 	defer close(in)
 
 	mockConn := new(ConnMock)
@@ -99,7 +99,7 @@ func (suite *ClientTestSuite) TestListenSuccess() {
 func (suite *ClientTestSuite) TestCloseConnectionWriteError() {
 	expectedError := errors.New("test")
 	interrupt := make(chan struct{})
-	in := make(chan websocket.ShellCommunication)
+	in := make(chan websocket.ShellIO)
 	defer close(in)
 
 	mockConn := new(ConnMock)
@@ -118,7 +118,7 @@ func (suite *ClientTestSuite) TestCloseConnectionWriteError() {
 func (suite *ClientTestSuite) TestConnectionError() {
     expectedError := errors.New("connection error")
 	interrupt := make(chan struct{})
-	in := make(chan websocket.ShellCommunication)
+	in := make(chan websocket.ShellIO)
 	defer close(interrupt)
 	defer close(in)
 
@@ -136,7 +136,7 @@ func (suite *ClientTestSuite) TestConnectionError() {
 func (suite *ClientTestSuite) TestReadMessageError() {
 	expectedError := errors.New("read error")
 	interrupt := make(chan struct{})
-	in := make(chan websocket.ShellCommunication)
+	in := make(chan websocket.ShellIO)
 	defer close(interrupt)
 	defer close(in)
 
@@ -155,14 +155,14 @@ func (suite *ClientTestSuite) TestReadMessageError() {
 
 func (suite *ClientTestSuite) TestWriteMessage() {
 	interrupt := make(chan struct{})
-	in := make(chan websocket.ShellCommunication)
+	in := make(chan websocket.ShellIO)
 	defer close(in)
 
-	testShellCommunication := websocket.ShellCommunication{
+	testShellIO := websocket.ShellIO{
 		ConnectionID: "test",
 		Message:      "test",
 	}
-	jsonShellCommunication, _ := json.Marshal(testShellCommunication)
+	jsonShellIO, _ := json.Marshal(testShellIO)
 
 	mockConn := new(ConnMock)
 	mockConn.MockClosed(nil)
@@ -170,12 +170,12 @@ func (suite *ClientTestSuite) TestWriteMessage() {
 	mockConn.On(
 		"WriteMessage",
 		gorilla.TextMessage,
-		jsonShellCommunication).Return(nil)
+		jsonShellIO).Return(nil)
 
 	wsClient := createWsClient(mockConn)
 	done := wsClient.Listen(u, oauth.AccessToken{}, &in, &interrupt)
 
-	in <- testShellCommunication
+	in <- testShellIO
 
 	close(interrupt)
 

--- a/websocket/client_test.go
+++ b/websocket/client_test.go
@@ -83,15 +83,15 @@ func (suite *ClientTestSuite) TestListenForShellIOSuccess() {
 
 	mockConn := new(ConnMock)
 	mockConn.MockClosed(nil)
-    mockConn.On("ReadMessage").Return(0, []byte("{\"command\": \"new connection\"}"), nil).Once()
+	mockConn.On("ReadMessage").Return(0, []byte("{\"command\": \"new connection\"}"), nil).Once()
 	mockConn.On("ReadMessage").Return(0, []byte("{\"message\": \"test message\"}"), nil)
 
 	wsClient := createWsClient(mockConn)
 	done := wsClient.Listen(u, oauth.AccessToken{}, &in, &interrupt)
-    command := <-wsClient.Commands()
+	command := <-wsClient.Commands()
 	message := <-wsClient.Out()
 
-    assert.Equal(suite.T(), "new connection", command.Command)
+	assert.Equal(suite.T(), "new connection", command.Command)
 	assert.Equal(suite.T(), "test message", message.Message)
 
 	close(interrupt)
@@ -120,7 +120,7 @@ func (suite *ClientTestSuite) TestCloseConnectionWriteError() {
 }
 
 func (suite *ClientTestSuite) TestConnectionError() {
-    expectedError := errors.New("connection error")
+	expectedError := errors.New("connection error")
 	interrupt := make(chan struct{})
 	in := make(chan websocket.ShellIO)
 	defer close(interrupt)
@@ -193,9 +193,9 @@ func TestClientSuite(t *testing.T) {
 }
 
 func createWsClient(mockConn *ConnMock) websocket.Client {
-    mockDialer := new(DialerMock)
+	mockDialer := new(DialerMock)
 	mockDialer.On("Dial", u.String(), http.Header{"Authorization": []string{" "}}).Return(mockConn, nil, nil)
 
 	wsClient := websocket.CreateClient(mockDialer)
-    return wsClient
+	return wsClient
 }

--- a/websocket/message.go
+++ b/websocket/message.go
@@ -1,0 +1,14 @@
+package websocket
+
+// ShellIO is used for communicating shell input, output and error streams.
+type ShellIO struct {
+	ConnectionID string `json:"connection_id"`
+	Message      string `json:"message"`
+}
+
+// Command is used to instruct the agent to execute a pre-defined command.
+type Command struct {
+    ConnectionID    string `json:"connection_id"`
+    Command         string `json:"command"`
+}
+

--- a/websocket/message.go
+++ b/websocket/message.go
@@ -8,7 +8,6 @@ type ShellIO struct {
 
 // Command is used to instruct the agent to execute a pre-defined command.
 type Command struct {
-    ConnectionID    string `json:"connection_id"`
-    Command         string `json:"command"`
+	ConnectionID string `json:"connection_id"`
+	Command      string `json:"command"`
 }
-


### PR DESCRIPTION
## Code R Ticket
_Please provide a link to the Code R Jira ticket if applicable_

<https://partypeak.atlassian.net/browse/AP-33>

## Description
Allows for shell IO messaging as well as execution of predefined commands. The first command implemented is to open a new connection. This way we can create the PTY session without getting the first shell input through Apollo so that we can already output any initial data from the session over the connection.

## Dependencies
_Are there any dependencies in relation to pull requests in other Apollo repositories? If so please provide links to these pull requests_

* https://github.com/thecoderstudio/apollo/pull/25

## Additional notes
Nope