### PR TITLE
AP-35 shell choice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           go-version: '^1.14.3'
 
+      - name: Install zsh to test on multiple shells
+        run: |
+          apt-get update
+          apt-get -y install zsh
+
       - name: Run tests
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Install zsh to test on multiple shells
         run: |
-          apt-get update
-          apt-get -y install zsh
+          sudo apt-get update
+          sudo apt-get -y install zsh
 
       - name: Run tests
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y install zsh
+          touch ~/.zshrc
 
       - name: Run tests
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var opts struct {
 	Host    string `short:"h" long:"host" description:"Host address" required:"true"`
 	AgentID string `long:"agent-id" description:"Apollo agent id" required:"true"`
 	Secret  string `long:"secret" description:"Apollo OAuth client secret" required:"true"`
-    Shell   string `long:"shell" description:"Path to shell" default:"/bin/bash"`
+	Shell   string `long:"shell" description:"Path to shell" default:"/bin/bash"`
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ var opts struct {
 	Host    string `short:"h" long:"host" description:"Host address" required:"true"`
 	AgentID string `long:"agent-id" description:"Apollo agent id" required:"true"`
 	Secret  string `long:"secret" description:"Apollo OAuth client secret" required:"true"`
+    Shell   string `long:"shell" description:"Path to shell" default:"/bin/bash"`
 }
 
 func main() {
@@ -61,7 +62,7 @@ func connect(accessTokenChan *chan oauth.AccessToken, initialToken oauth.AccessT
 	in := make(chan websocket.ShellIO)
 	defer close(in)
 
-	ptyManager := pty.CreateManager(&in)
+	ptyManager := pty.CreateManager(&in, opts.Shell)
 	defer ptyManager.Close()
 
 	done := wsClient.Listen(u, initialToken, &in, &interrupt)

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -10,6 +10,7 @@ const NewConnection = "new connection"
 // Manager helps managing multiple PTY sessions by finding or creating the
 // correct session based on ShellIO.ConnectionID and handling execution.
 type Manager struct {
+    shell string
 	sessions map[string]*Session
 	out      *chan websocket.ShellIO
 }
@@ -42,7 +43,7 @@ func (manager *Manager) GetSession(sessionID string) *Session {
 // CreateNewSession creates a new PTY session for the given ID,
 // overwriting the existing session for this ID if present.
 func (manager *Manager) CreateNewSession(sessionID string) *Session {
-	pty := CreateSession(sessionID)
+	pty := CreateSession(sessionID, manager.shell)
 	manager.sessions[sessionID] = pty
 	out := pty.Out()
 	go manager.writeOutput(&out)
@@ -63,9 +64,11 @@ func (manager *Manager) Close() {
 	}
 }
 
-// CreateManager creates a Manager with the required out channel.
-func CreateManager(out *chan websocket.ShellIO) Manager {
+// CreateManager creates a Manager with the required out channel. All sessions will get created
+// with the given shell.
+func CreateManager(out *chan websocket.ShellIO, shell string) Manager {
 	return Manager{
+        shell: shell,
 		sessions: map[string]*Session{},
 		out:      out,
 	}

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -10,7 +10,7 @@ const NewConnection = "new connection"
 // Manager helps managing multiple PTY sessions by finding or creating the
 // correct session based on ShellIO.ConnectionID and handling execution.
 type Manager struct {
-    shell string
+	shell    string
 	sessions map[string]*Session
 	out      *chan websocket.ShellIO
 }
@@ -68,7 +68,7 @@ func (manager *Manager) Close() {
 // with the given shell.
 func CreateManager(out *chan websocket.ShellIO, shell string) Manager {
 	return Manager{
-        shell: shell,
+		shell:    shell,
 		sessions: map[string]*Session{},
 		out:      out,
 	}

--- a/pty/manager_test.go
+++ b/pty/manager_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestCreateManager(t *testing.T) {
 	out := make(chan websocket.ShellIO)
-	manager := pty.CreateManager(&out)
+	manager := pty.CreateManager(&out, "/bin/bash")
 
 	assert.NotNil(t, manager)
 
@@ -20,7 +20,7 @@ func TestCreateManager(t *testing.T) {
 
 func TestNewConnectionCommand(t *testing.T) {
 	out := make(chan websocket.ShellIO)
-	manager := pty.CreateManager(&out)
+	manager := pty.CreateManager(&out, "/bin/bash")
 
 	manager.ExecutePredefinedCommand(websocket.Command{
 		ConnectionID: "test",
@@ -34,7 +34,7 @@ func TestNewConnectionCommand(t *testing.T) {
 
 func TestGetSession(t *testing.T) {
 	out := make(chan websocket.ShellIO)
-	manager := pty.CreateManager(&out)
+	manager := pty.CreateManager(&out, "/bin/bash")
 
 	session := manager.CreateNewSession("test")
 
@@ -45,21 +45,21 @@ func TestGetSession(t *testing.T) {
 
 func TestGetSessionNotFound(t *testing.T) {
 	out := make(chan websocket.ShellIO)
-	manager := pty.CreateManager(&out)
+	manager := pty.CreateManager(&out, "/bin/bash")
 
 	assert.Nil(t, manager.GetSession("test"))
 }
 
 func TestCreateNewSession(t *testing.T) {
 	out := make(chan websocket.ShellIO)
-	manager := pty.CreateManager(&out)
+	manager := pty.CreateManager(&out, "/bin/bash")
 
 	assert.NotNil(t, manager.CreateNewSession("test"))
 }
 
 func TestManagerExecute(t *testing.T) {
 	out := make(chan websocket.ShellIO)
-	manager := pty.CreateManager(&out)
+	manager := pty.CreateManager(&out, "/bin/bash")
 
 	manager.Execute(websocket.ShellIO{
 		ConnectionID: "test",

--- a/pty/session.go
+++ b/pty/session.go
@@ -14,6 +14,7 @@ import (
 // through the Session.Out channel.
 type Session struct {
 	SessionID string
+    shell string
 	session   *os.File
 	out       *chan websocket.ShellIO
 	closed    bool
@@ -47,7 +48,7 @@ func (ptySession *Session) Execute(toBeExecuted string) error {
 }
 
 func (ptySession *Session) createNewSession() error {
-	cmd := exec.Command("/bin/bash")
+	cmd := exec.Command(ptySession.shell)
 	session, err := pty.Start(cmd)
 
 	ptySession.session = session
@@ -80,11 +81,12 @@ func (ptySession *Session) Close() {
 	close(*ptySession.out)
 }
 
-// CreateSession creates a new Session injected with the given sessionID and defaults.
-func CreateSession(sessionID string) *Session {
+// CreateSession creates a new Session injected with the given sessionID, the given shell and defaults.
+func CreateSession(sessionID, shell string) *Session {
 	out := make(chan websocket.ShellIO)
 	ptySession := Session{
 		SessionID: sessionID,
+        shell: shell,
 		out:       &out,
 		closed:    false,
 	}

--- a/pty/session.go
+++ b/pty/session.go
@@ -14,7 +14,7 @@ import (
 // through the Session.Out channel.
 type Session struct {
 	SessionID string
-    shell string
+	shell     string
 	session   *os.File
 	out       *chan websocket.ShellIO
 	closed    bool
@@ -86,7 +86,7 @@ func CreateSession(sessionID, shell string) *Session {
 	out := make(chan websocket.ShellIO)
 	ptySession := Session{
 		SessionID: sessionID,
-        shell: shell,
+		shell:     shell,
 		out:       &out,
 		closed:    false,
 	}

--- a/pty/session_test.go
+++ b/pty/session_test.go
@@ -26,7 +26,7 @@ func TestExecuteEmptyCommand(t *testing.T) {
 }
 
 func TestExecute(t *testing.T) {
-	shellsForTesting := []string{"/bin/bash", "/bin/sh"}
+	shellsForTesting := []string{"/bin/bash", "/bin/zsh"}
 
 	for _, shell := range shellsForTesting {
 		t.Run(shell, func(t *testing.T) {

--- a/pty/session_test.go
+++ b/pty/session_test.go
@@ -26,25 +26,25 @@ func TestExecuteEmptyCommand(t *testing.T) {
 }
 
 func TestExecute(t *testing.T) {
-    shellsForTesting := []string{"/bin/bash", "/bin/sh"}
+	shellsForTesting := []string{"/bin/bash", "/bin/sh"}
 
-    for _, shell := range shellsForTesting {
-        t.Run(shell, func(t *testing.T) {
-            pty := pty.CreateSession("test", shell)
-            defer pty.Close()
+	for _, shell := range shellsForTesting {
+		t.Run(shell, func(t *testing.T) {
+			pty := pty.CreateSession("test", shell)
+			defer pty.Close()
 
-            pty.Execute("echo 1")
+			pty.Execute("echo 1")
 
-            outChan := pty.Out()
-            output := <-outChan
-            assert.Contains(t, output.Message, "echo 1")
-            assert.NotNil(t, pty.Session())
+			outChan := pty.Out()
+			output := <-outChan
+			assert.Contains(t, output.Message, "echo 1")
+			assert.NotNil(t, pty.Session())
 
-            pty.Execute("echo 2")
-            output = <-outChan
-            assert.Contains(t, output.Message, "echo 2")
-        })
-    }
+			pty.Execute("echo 2")
+			output = <-outChan
+			assert.Contains(t, output.Message, "echo 2")
+		})
+	}
 }
 
 func TestExecuteOnClosed(t *testing.T) {

--- a/pty/session_test.go
+++ b/pty/session_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCreateSession(t *testing.T) {
-	pty := pty.CreateSession("test")
+	pty := pty.CreateSession("test", "/bin/bash")
 	defer pty.Close()
 
 	assert.Equal(t, pty.SessionID, "test")
@@ -18,7 +18,7 @@ func TestCreateSession(t *testing.T) {
 }
 
 func TestExecuteEmptyCommand(t *testing.T) {
-	pty := pty.CreateSession("test")
+	pty := pty.CreateSession("test", "/bin/bash")
 	defer pty.Close()
 
 	pty.Execute("")
@@ -26,23 +26,29 @@ func TestExecuteEmptyCommand(t *testing.T) {
 }
 
 func TestExecute(t *testing.T) {
-	pty := pty.CreateSession("test")
-	defer pty.Close()
+    shellsForTesting := []string{"/bin/bash", "/bin/sh"}
 
-	pty.Execute("echo 1")
+    for _, shell := range shellsForTesting {
+        t.Run(shell, func(t *testing.T) {
+            pty := pty.CreateSession("test", shell)
+            defer pty.Close()
 
-	outChan := pty.Out()
-	output := <-outChan
-	assert.Contains(t, output.Message, "echo 1")
-	assert.NotNil(t, pty.Session())
+            pty.Execute("echo 1")
 
-	pty.Execute("echo 2")
-	output = <-outChan
-	assert.Contains(t, output.Message, "echo 2")
+            outChan := pty.Out()
+            output := <-outChan
+            assert.Contains(t, output.Message, "echo 1")
+            assert.NotNil(t, pty.Session())
+
+            pty.Execute("echo 2")
+            output = <-outChan
+            assert.Contains(t, output.Message, "echo 2")
+        })
+    }
 }
 
 func TestExecuteOnClosed(t *testing.T) {
-	pty := pty.CreateSession("test")
+	pty := pty.CreateSession("test", "/bin/bash")
 	pty.Close()
 	err := pty.Execute("echo 1")
 	assert.EqualError(t, err, "session is closed, please create a new session")


### PR DESCRIPTION
## Code R Ticket
_Please provide a link to the Code R Jira ticket if applicable_

<https://partypeak.atlassian.net/browse/AP-35>

## Description
Allows you to pass a path to the shell you the agent PTY session to run with `--shell /bin/zsh`. Defaults to `/bin/bash`.

## Dependencies
_Are there any dependencies in relation to pull requests in other Apollo repositories? If so please provide links to these pull requests_

* https://github.com/thecoderstudio/apollo-agent/pull/7

## Additional notes
Nope
