### PR TITLE
AP-40 handle shell failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ var opts struct {
 func main() {
 	log.SetFlags(0)
 	parseArguments()
-	verifyShell(opts.Shell)
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
@@ -41,13 +40,6 @@ func parseArguments() {
 	_, err := flags.Parse(&opts)
 	if err != nil {
 		panic(err)
-	}
-}
-
-func verifyShell(shell string) {
-	err := pty.Verify(shell)
-	if err != nil {
-		log.Fatal(err)
 	}
 }
 
@@ -79,7 +71,10 @@ func connect(
 	in := make(chan websocket.ShellIO)
 	defer close(in)
 
-	ptyManager := pty.CreateManager(&in, opts.Shell)
+	ptyManager, err := pty.CreateManager(&in, opts.Shell)
+    if err != nil {
+        log.Fatal(err)
+    }
 	defer ptyManager.Close()
 
 	done := wsClient.Listen(u, initialToken, &in, &interrupt)

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var opts struct {
 func main() {
 	log.SetFlags(0)
 	parseArguments()
+	verifyShell(opts.Shell)
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
@@ -40,6 +41,13 @@ func parseArguments() {
 	_, err := flags.Parse(&opts)
 	if err != nil {
 		panic(err)
+	}
+}
+
+func verifyShell(shell string) {
+	err := pty.Verify(shell)
+	if err != nil {
+		log.Fatal(err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -72,9 +72,9 @@ func connect(
 	defer close(in)
 
 	ptyManager, err := pty.CreateManager(&in, opts.Shell)
-    if err != nil {
-        log.Fatal(err)
-    }
+	if err != nil {
+		log.Fatal(err)
+	}
 	defer ptyManager.Close()
 
 	done := wsClient.Listen(u, initialToken, &in, &interrupt)

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -15,7 +15,7 @@ type Manager struct {
 	Shell    string
 	sessions map[string]*Session
 	out      *chan websocket.ShellIO
-	done      *chan bool
+	done     *chan bool
 }
 
 // ExecutePredefinedCommand executes the pre-defined command if it exists.
@@ -53,10 +53,10 @@ func (manager *Manager) GetSession(sessionID string) *Session {
 func (manager *Manager) CreateNewSession(sessionID string) (*Session, error) {
 	pty, err := CreateSession(sessionID, manager.Shell)
 	if err != nil {
-        manager.writeError(sessionID, err)
+		manager.writeError(sessionID, err)
 		log.Println(err)
-        pty.Close()
-        return nil, err
+		pty.Close()
+		return nil, err
 	}
 
 	manager.sessions[sessionID] = pty
@@ -75,19 +75,19 @@ func (manager *Manager) writeError(sessionID string, err error) {
 
 func (manager *Manager) writeOutput(in *<-chan websocket.ShellIO) {
 	for {
-        select {
-        case <-*manager.done:
-            return
-        default:
-            message := <-*in
-            *manager.out <- message
-        }
+		select {
+		case <-*manager.done:
+			return
+		default:
+			message := <-*in
+			*manager.out <- message
+		}
 	}
 }
 
 // Close closes all sessions.
 func (manager *Manager) Close() {
-    close(*manager.done)
+	close(*manager.done)
 	for _, pty := range manager.sessions {
 		pty.Close()
 	}
@@ -102,12 +102,12 @@ func CreateManager(out *chan websocket.ShellIO, shell string) (Manager, error) {
 		return manager, err
 	}
 
-    done := make(chan bool)
+	done := make(chan bool)
 	manager = Manager{
 		Shell:    shell,
 		sessions: map[string]*Session{},
 		out:      out,
-        done: &done,
+		done:     &done,
 	}
 
 	return manager, err

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -51,18 +51,18 @@ func (manager *Manager) GetSession(sessionID string) *Session {
 // CreateNewSession creates a new PTY session for the given ID,
 // overwriting the existing session for this ID if present.
 func (manager *Manager) CreateNewSession(sessionID string) (*Session, error) {
-	session, err := CreateSession(sessionID, manager.Shell)
+	pty, err := CreateSession(sessionID, manager.Shell)
 	if err != nil {
+        manager.writeError(sessionID, err)
 		log.Println(err)
-		manager.writeError(sessionID, err)
-		session.Close()
-		return nil, err
+        pty.Close()
+        return nil, err
 	}
 
-	manager.sessions[sessionID] = session
-	out := session.Out()
+	manager.sessions[sessionID] = pty
+	out := pty.Out()
 	go manager.writeOutput(&out)
-	return session, nil
+	return pty, err
 }
 
 func (manager *Manager) writeError(sessionID string, err error) {

--- a/pty/manager.go
+++ b/pty/manager.go
@@ -1,7 +1,7 @@
 package pty
 
 import (
-    "log"
+	"log"
 
 	"github.com/thecoderstudio/apollo-agent/websocket"
 )
@@ -46,12 +46,12 @@ func (manager *Manager) GetSession(sessionID string) *Session {
 // overwriting the existing session for this ID if present.
 func (manager *Manager) CreateNewSession(sessionID string) *Session {
 	pty, err := CreateSession(sessionID, manager.shell)
-    if err != nil {
-        log.Println(err)
-        manager.writeError(sessionID, err)
-        pty.Close()
-        return nil
-    }
+	if err != nil {
+		log.Println(err)
+		manager.writeError(sessionID, err)
+		pty.Close()
+		return nil
+	}
 
 	manager.sessions[sessionID] = pty
 	out := pty.Out()
@@ -60,11 +60,11 @@ func (manager *Manager) CreateNewSession(sessionID string) *Session {
 }
 
 func (manager *Manager) writeError(sessionID string, err error) {
-    errMessage := websocket.ShellIO{
-        ConnectionID: sessionID,
-        Message: err.Error(),
-    }
-    *manager.out <- errMessage
+	errMessage := websocket.ShellIO{
+		ConnectionID: sessionID,
+		Message:      err.Error(),
+	}
+	*manager.out <- errMessage
 }
 
 func (manager *Manager) writeOutput(in *<-chan websocket.ShellIO) {

--- a/pty/manager_test.go
+++ b/pty/manager_test.go
@@ -71,21 +71,21 @@ func TestCreateNewSession(t *testing.T) {
 
 func TestCreateNewSessionInvalidShell(t *testing.T) {
 	out := make(chan websocket.ShellIO)
-    expectedErrMessage := "fork/exec /bin/fake: no such file or directory"
+	expectedErrMessage := "fork/exec /bin/fake: no such file or directory"
 	manager, _ := pty.CreateManager(&out, "/bin/bash")
 	manager.Shell = "/bin/fake"
 
-    go func() {
-        session, err := manager.CreateNewSession("test")
-        assert.Nil(t, session)
-        assert.EqualError(t, err, expectedErrMessage)
-    }()
+	go func() {
+		session, err := manager.CreateNewSession("test")
+		assert.Nil(t, session)
+		assert.EqualError(t, err, expectedErrMessage)
+	}()
 
-    writtenErr := <-out
+	writtenErr := <-out
 	assert.Equal(t, writtenErr, websocket.ShellIO{
-        ConnectionID: "test",
-        Message: expectedErrMessage,
-    })
+		ConnectionID: "test",
+		Message:      expectedErrMessage,
+	})
 
 	manager.Close()
 }
@@ -114,23 +114,23 @@ func TestManagerExecute(t *testing.T) {
 
 func TestManagerExecuteInvalidShell(t *testing.T) {
 	out := make(chan websocket.ShellIO)
-    expectedErrMessage := "fork/exec /bin/fake: no such file or directory"
-    manager, _ := pty.CreateManager(&out, "/bin/bash")
-    manager.Shell = "/bin/fake"
+	expectedErrMessage := "fork/exec /bin/fake: no such file or directory"
+	manager, _ := pty.CreateManager(&out, "/bin/bash")
+	manager.Shell = "/bin/fake"
 
-    go func() {
-        err := manager.Execute(websocket.ShellIO{
-            ConnectionID: "test",
-            Message:      "echo 1",
-        })
-        assert.EqualError(t, err, expectedErrMessage)
-    }()
-    writtenErr := <-out
+	go func() {
+		err := manager.Execute(websocket.ShellIO{
+			ConnectionID: "test",
+			Message:      "echo 1",
+		})
+		assert.EqualError(t, err, expectedErrMessage)
+	}()
+	writtenErr := <-out
 
 	assert.Equal(t, writtenErr, websocket.ShellIO{
-        ConnectionID: "test",
-        Message: expectedErrMessage,
-    })
+		ConnectionID: "test",
+		Message:      expectedErrMessage,
+	})
 
-    manager.Close()
+	manager.Close()
 }

--- a/pty/manager_test.go
+++ b/pty/manager_test.go
@@ -14,16 +14,16 @@ func TestCreateManager(t *testing.T) {
 	manager, err := pty.CreateManager(&out, "/bin/bash")
 
 	assert.NotNil(t, manager)
-    assert.NoError(t, err)
+	assert.NoError(t, err)
 
 	manager.Close()
 }
 
-func CreateManagerInvalidShell(t *testing.T) {
+func TestCreateManagerInvalidShell(t *testing.T) {
 	out := make(chan websocket.ShellIO)
-    _, err := pty.CreateManager(&out, "/bin/fake")
+	_, err := pty.CreateManager(&out, "/bin/fake")
 
-    assert.EqualError(t, err, "fork/exec /bin/fake: no such file or directory")
+	assert.EqualError(t, err, "fork/exec /bin/fake: no such file or directory")
 }
 
 func TestNewConnectionCommand(t *testing.T) {
@@ -61,22 +61,25 @@ func TestGetSessionNotFound(t *testing.T) {
 func TestCreateNewSession(t *testing.T) {
 	out := make(chan websocket.ShellIO)
 	manager, _ := pty.CreateManager(&out, "/bin/bash")
-    session, err := manager.CreateNewSession("test")
+	session, err := manager.CreateNewSession("test")
 
 	assert.NotNil(t, session)
-    assert.NoError(t, err)
+	assert.NoError(t, err)
+
+	manager.Close()
 }
 
 func TestCreateNewSessionInvalidShell(t *testing.T) {
 	out := make(chan websocket.ShellIO)
-	pty.CreateManager(&out, "/bin/fake")
+	manager, _ := pty.CreateManager(&out, "/bin/bash")
+	manager.Shell = "/bin/fake"
 
-    //session, err := manager.CreateNewSession("test")
-    //writtenErr := <-out
+	//session, err := manager.CreateNewSession("test")
 
-    //assert.Nil(t, session)
-    //assert.EqualError(t, err, "fork/exec /bin/fake: no such file or directory")
-    //assert.Equal(t, writtenErr, websocket.ShellIO{ConnectionID: "test", Message: err.Error()})
+	//assert.Nil(t, session)
+	//assert.EqualError(t, err, "fork/exec /bin/fake: no such file or directory")
+
+	manager.Close()
 }
 
 func TestManagerExecute(t *testing.T) {
@@ -103,13 +106,13 @@ func TestManagerExecute(t *testing.T) {
 
 func TestManagerExecuteInvalidShell(t *testing.T) {
 	out := make(chan websocket.ShellIO)
-    pty.CreateManager(&out, "/bin/fake")
+	pty.CreateManager(&out, "/bin/fake")
 
-    // err := manager.Execute(websocket.ShellIO{
+	// err := manager.Execute(websocket.ShellIO{
 	//	ConnectionID: "test",
 	//	Message:      "echo 1",
 	//})
 
-    //assert.EqualError(t, err, "fork/exec /bin/fake: no such file or directory")
-    //assert.Equal(t, writtenErr, websocket.ShellIO{ConnectionID: "test", Message: err.Error()})
+	//assert.EqualError(t, err, "fork/exec /bin/fake: no such file or directory")
+	//assert.Equal(t, writtenErr, websocket.ShellIO{ConnectionID: "test", Message: err.Error()})
 }

--- a/pty/pty.go
+++ b/pty/pty.go
@@ -1,0 +1,21 @@
+package pty
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/creack/pty"
+)
+
+// Start starts and returns an open PTY session with the given shell command.
+func Start(shell string) (*os.File, error) {
+	cmd := exec.Command(shell)
+	return pty.Start(cmd)
+}
+
+// Verify verifies the given shell command, returning an error if invalid.
+func Verify(shell string) error {
+	session, err := Start(shell)
+	session.Close()
+	return err
+}

--- a/pty/pty_test.go
+++ b/pty/pty_test.go
@@ -1,0 +1,26 @@
+package pty_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/thecoderstudio/apollo-agent/pty"
+)
+
+func TestStartWithError(t *testing.T) {
+	session, err := pty.Start("/bin/fake")
+	defer session.Close()
+	assert.Nil(t, session)
+	assert.EqualError(t, err, "fork/exec /bin/fake: no such file or directory")
+}
+
+func TestVerifyValid(t *testing.T) {
+	err := pty.Verify("/bin/bash")
+	assert.NoError(t, err)
+}
+
+func TestVerifyInvalid(t *testing.T) {
+	err := pty.Verify("/bin/fake")
+	assert.EqualError(t, err, "fork/exec /bin/fake: no such file or directory")
+}

--- a/pty/session.go
+++ b/pty/session.go
@@ -47,11 +47,14 @@ func (ptySession *Session) Execute(toBeExecuted string) error {
 
 func (ptySession *Session) createNewSession() error {
 	session, err := Start(ptySession.shell)
+	if err != nil {
+		return err
+	}
 
 	ptySession.session = session
 	go ptySession.listen(ptySession.session)
 
-	return err
+	return nil
 }
 
 func (ptySession *Session) listen(session *os.File) {

--- a/pty/session.go
+++ b/pty/session.go
@@ -91,7 +91,7 @@ func (ptySession *Session) closeSession() {
 }
 
 // CreateSession creates a new Session injected with the given sessionID, the given shell and defaults.
-func CreateSession(sessionID, shell string) *Session {
+func CreateSession(sessionID, shell string) (*Session, error) {
 	out := make(chan websocket.ShellIO)
 	done := make(chan bool)
 	ptySession := Session{
@@ -101,6 +101,6 @@ func CreateSession(sessionID, shell string) *Session {
 		done:      &done,
 		closed:    false,
 	}
-	ptySession.createNewSession()
-	return &ptySession
+    err := ptySession.createNewSession()
+	return &ptySession, err
 }

--- a/pty/session.go
+++ b/pty/session.go
@@ -47,14 +47,11 @@ func (ptySession *Session) Execute(toBeExecuted string) error {
 
 func (ptySession *Session) createNewSession() error {
 	session, err := Start(ptySession.shell)
-	if err != nil {
-		return err
-	}
 
 	ptySession.session = session
 	go ptySession.listen(ptySession.session)
 
-	return nil
+	return err
 }
 
 func (ptySession *Session) listen(session *os.File) {

--- a/pty/session.go
+++ b/pty/session.go
@@ -3,9 +3,6 @@ package pty
 import (
 	"errors"
 	"os"
-	"os/exec"
-
-	"github.com/creack/pty"
 
 	"github.com/thecoderstudio/apollo-agent/websocket"
 )
@@ -49,8 +46,7 @@ func (ptySession *Session) Execute(toBeExecuted string) error {
 }
 
 func (ptySession *Session) createNewSession() error {
-	cmd := exec.Command(ptySession.shell)
-	session, err := pty.Start(cmd)
+	session, err := Start(ptySession.shell)
 
 	ptySession.session = session
 	go ptySession.listen(ptySession.session)
@@ -101,6 +97,6 @@ func CreateSession(sessionID, shell string) (*Session, error) {
 		done:      &done,
 		closed:    false,
 	}
-    err := ptySession.createNewSession()
+	err := ptySession.createNewSession()
 	return &ptySession, err
 }

--- a/pty/session_test.go
+++ b/pty/session_test.go
@@ -12,7 +12,7 @@ func TestCreateSession(t *testing.T) {
 	pty, err := pty.CreateSession("test", "/bin/bash")
 	defer pty.Close()
 
-    assert.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, pty.SessionID, "test")
 	assert.NotNil(t, pty.Session())
 	assert.NotNil(t, pty.Out())
@@ -22,7 +22,7 @@ func TestCreateSessionInvalidShell(t *testing.T) {
 	pty, err := pty.CreateSession("test", "/bin/fake")
 	defer pty.Close()
 
-    assert.EqualError(t, err, "fork/exec /bin/fake: no such file or directory")
+	assert.EqualError(t, err, "fork/exec /bin/fake: no such file or directory")
 }
 
 func TestExecuteEmptyCommand(t *testing.T) {

--- a/pty/session_test.go
+++ b/pty/session_test.go
@@ -9,16 +9,24 @@ import (
 )
 
 func TestCreateSession(t *testing.T) {
-	pty := pty.CreateSession("test", "/bin/bash")
+	pty, err := pty.CreateSession("test", "/bin/bash")
 	defer pty.Close()
 
+    assert.NoError(t, err)
 	assert.Equal(t, pty.SessionID, "test")
 	assert.NotNil(t, pty.Session())
 	assert.NotNil(t, pty.Out())
 }
 
+func TestCreateSessionInvalidShell(t *testing.T) {
+	pty, err := pty.CreateSession("test", "/bin/fake")
+	defer pty.Close()
+
+    assert.EqualError(t, err, "fork/exec /bin/fake: no such file or directory")
+}
+
 func TestExecuteEmptyCommand(t *testing.T) {
-	pty := pty.CreateSession("test", "/bin/bash")
+	pty, _ := pty.CreateSession("test", "/bin/bash")
 	defer pty.Close()
 
 	pty.Execute("")
@@ -30,7 +38,7 @@ func TestExecute(t *testing.T) {
 
 	for _, shell := range shellsForTesting {
 		t.Run(shell, func(t *testing.T) {
-			pty := pty.CreateSession("test", shell)
+			pty, _ := pty.CreateSession("test", shell)
 			defer pty.Close()
 
 			pty.Execute("echo 1")
@@ -48,7 +56,7 @@ func TestExecute(t *testing.T) {
 }
 
 func TestExecuteOnClosed(t *testing.T) {
-	pty := pty.CreateSession("test", "/bin/bash")
+	pty, _ := pty.CreateSession("test", "/bin/bash")
 	pty.Close()
 	err := pty.Execute("echo 1")
 	assert.EqualError(t, err, "session is closed, please create a new session")


### PR DESCRIPTION
## Code R Ticket
_Please provide a link to the Code R Jira ticket if applicable_

<https://partypeak.atlassian.net/browse/AP-40>

## Description
Informs the user when there's a problem with the given shell (doesn't exist / no permission). 

* Verifies the shell on agent start so the problem is immediately known.
* Communicates the error over the websocket connection if it happens later. Even though we perform verification at the start this could still occur if the owner of the machine uninstalls the shell for example.

## Dependencies
_Are there any dependencies in relation to pull requests in other Apollo repositories? If so please provide links to these pull requests_

*

## Additional notes
Nope