### PR TITLE
AP-71 improve test consistency

### DIFF
--- a/action/action_test.go
+++ b/action/action_test.go
@@ -49,6 +49,7 @@ func TestExecuteLinPeas(t *testing.T) {
 
 	finishedCommand := <-*out
 
+	sessionMock.AssertExpectations(t)
 	assert.Equal(t, finishedCommand, expectedFinishedCommand)
 	assert.Nil(t, err)
 }

--- a/action/command_test.go
+++ b/action/command_test.go
@@ -51,6 +51,7 @@ func TestWaitForCompletion(t *testing.T) {
 
 	finishedCommand := <-out
 	assert.Equal(t, finishedCommand, expectedFinishedCommand)
+	sessionMock.AssertExpectations(t)
 }
 
 func TestCreateCommandObserver(t *testing.T) {

--- a/action/linpeas_test.go
+++ b/action/linpeas_test.go
@@ -51,6 +51,7 @@ func TestRun(t *testing.T) {
 
 	finishedCommand := <-out
 	assert.Equal(t, finishedCommand, expectedFinishedCommand)
+	sessionMock.AssertExpectations(t)
 }
 
 func TestCreateLinPeas(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.14
 require (
 	github.com/creack/pty v1.1.11
 	github.com/dustin/go-broadcast v0.0.0-20171205050544-f664265f5a66
+	github.com/eapache/channels v1.1.0
+	github.com/eapache/queue v1.1.0 // indirect
 	github.com/fatih/color v1.9.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/jessevdk/go-flags v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-broadcast v0.0.0-20171205050544-f664265f5a66 h1:QnnoVdChKs+GeTvN4rPYTW6b5U6M3HMEvQ/+x4IGtfY=
 github.com/dustin/go-broadcast v0.0.0-20171205050544-f664265f5a66/go.mod h1:kTEh6M2J/mh7nsskr28alwLCXm/DSG5OSA/o31yy2XU=
+github.com/eapache/channels v1.1.0 h1:F1taHcn7/F0i8DYqKXJnyhJcVpp2kgFcNePxXtnyu4k=
+github.com/eapache/channels v1.1.0/go.mod h1:jMm2qB5Ubtg9zLd+inMZd2/NUvXgzmWXsDaLyQIGfH0=
+github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
+github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/pty/session_test.go
+++ b/pty/session_test.go
@@ -1,6 +1,7 @@
 package pty_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,12 +51,19 @@ func TestExecute(t *testing.T) {
 
 			broadcaster := *pty.Out()
 			broadcaster.Register(outChan)
-			output := <-outChan
-			assert.Contains(t, output.(websocket.ShellIO).Message, "echo 1")
 			assert.NotNil(t, pty.Session())
 
+			message := ""
+			for {
+				output := <-outChan
+				message = message + output.(websocket.ShellIO).Message
+				if strings.Contains(message, "echo 1") {
+					break
+				}
+			}
+
 			pty.Execute("echo 2")
-			output = <-outChan
+			output := <-outChan
 			assert.Contains(t, output.(websocket.ShellIO).Message, "echo 2")
 		})
 	}

--- a/pty/session_test.go
+++ b/pty/session_test.go
@@ -1,12 +1,12 @@
 package pty_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/thecoderstudio/apollo-agent/pty"
+	"github.com/thecoderstudio/apollo-agent/testutil"
 	"github.com/thecoderstudio/apollo-agent/websocket"
 )
 
@@ -53,14 +53,12 @@ func TestExecute(t *testing.T) {
 			broadcaster.Register(outChan)
 			assert.NotNil(t, pty.Session())
 
-			message := ""
-			for {
-				output := <-outChan
-				message = message + output.(websocket.ShellIO).Message
-				if strings.Contains(message, "echo 1") {
-					break
-				}
-			}
+			// Depending on the test environment there may be garbage before the initial echo.
+			testutil.BlockUntilContains(
+				outChan,
+				func(output interface{}) string { return output.(websocket.ShellIO).Message },
+				"echo 1",
+			)
 
 			pty.Execute("echo 2")
 			output := <-outChan

--- a/shell/manager_test.go
+++ b/shell/manager_test.go
@@ -1,15 +1,16 @@
 package shell_test
 
 import (
-	"strings"
 	"testing"
 
+	"github.com/eapache/channels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/thecoderstudio/apollo-agent/action"
 	"github.com/thecoderstudio/apollo-agent/mocks"
 	"github.com/thecoderstudio/apollo-agent/shell"
+	"github.com/thecoderstudio/apollo-agent/testutil"
 	"github.com/thecoderstudio/apollo-agent/websocket"
 )
 
@@ -92,25 +93,25 @@ func TestManagerExecute(t *testing.T) {
 
 	manager.Execute(websocket.ShellIO{
 		ConnectionID: "test",
-		Message:      "echo 1",
+		Message:      "echo 1\n",
 	})
-	firstMessage := ""
+
 	// Depending on the test environment there may be garbage before the initial echo.
-	for {
-		first := <-manager.Out()
-		firstMessage = firstMessage + first.(websocket.ShellIO).Message
-		if strings.Contains(firstMessage, "echo 1") {
-			break
-		}
-	}
+	testutil.BlockUntilContains(
+		channels.Wrap(manager.Out()).Out(),
+		func(output interface{}) string { return output.(websocket.ShellIO).Message },
+		"echo 1",
+	)
 
 	manager.Execute(websocket.ShellIO{
 		ConnectionID: "test",
-		Message:      "echo 2",
+		Message:      "echo 2\n",
 	})
-	second := <-manager.Out()
-
-	assert.Contains(t, second.(websocket.ShellIO).Message, "echo 2")
+	testutil.BlockUntilContains(
+		channels.Wrap(manager.Out()).Out(),
+		func(output interface{}) string { return output.(websocket.ShellIO).Message },
+		"echo 2",
+	)
 
 	manager.Close()
 }

--- a/shell/manager_test.go
+++ b/shell/manager_test.go
@@ -1,6 +1,7 @@
 package shell_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,7 +94,15 @@ func TestManagerExecute(t *testing.T) {
 		ConnectionID: "test",
 		Message:      "echo 1",
 	})
-	first := <-manager.Out()
+	firstMessage := ""
+	// Depending on the test environment there may be garbage before the initial echo.
+	for {
+		first := <-manager.Out()
+		firstMessage = firstMessage + first.(websocket.ShellIO).Message
+		if strings.Contains(firstMessage, "echo 1") {
+			break
+		}
+	}
 
 	manager.Execute(websocket.ShellIO{
 		ConnectionID: "test",
@@ -101,7 +110,6 @@ func TestManagerExecute(t *testing.T) {
 	})
 	second := <-manager.Out()
 
-	assert.Contains(t, first.(websocket.ShellIO).Message, "echo 1")
 	assert.Contains(t, second.(websocket.ShellIO).Message, "echo 2")
 
 	manager.Close()

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,0 +1,21 @@
+package testutil
+
+import "strings"
+
+// BlockUntilContains will block and continuously read the channel until the subString is
+// found in the TOTAL output of the channel. Transform is used to transform a singular channel
+// output to a string.
+func BlockUntilContains(
+	channel <-chan interface{},
+	transform func(interface{}) string,
+	subString string,
+) {
+	readOutput := ""
+	for {
+		output := <-channel
+		readOutput = readOutput + transform(output)
+		if strings.ContainsAny(readOutput, subString) {
+			break
+		}
+	}
+}


### PR DESCRIPTION
## Code R Ticket
_Please provide a link to the Code R Jira ticket if applicable_

<https://partypeak.atlassian.net/browse/AP-71>

## Description

The agent tests sometimes fail because on initial shell interaction it’ll first return some garbage. This PR updates the affected tests to empty the shell output channel until the expected string has been found before it continues.

## Dependencies
_Are there any dependencies in relation to pull requests in other Apollo repositories? If so please provide links to these pull requests_

*

## Additional notes
Nope
