### PR TITLE
CODER-128 migrate to binary Codecov uploader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,16 @@ jobs:
       - name: Upload coverage report
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          CODECOV_BASH_URL: https://codecov.io/bash
-          CODECOV_SHASUM_URL: https://raw.githubusercontent.com/codecov/codecov-bash/master/SHA256SUM
+          CODECOV_BINARY_URL: https://uploader.codecov.io/latest/linux/codecov
+          CODECOV_SHASUM_URL: https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+          CODECOV_SHASUM_SIGNATURE_URL: https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+          CODECOV_PGP_KEY_URL: https://keybase.io/codecovsecurity/pgp_keys.asc
         run: |
-          curl -s $CODECOV_BASH_URL > codecov
+          curl -s $CODECOV_BINARY_URL > codecov
           chmod +x codecov
-          curl --location --show-error --silent -s $CODECOV_SHASUM_URL | head -1 | sha256sum --check \
-              && ./codecov
+          curl $CODECOV_PGP_KEY_URL | gpg --import
+          curl -Os $CODECOV_SHASUM_URL
+          curl -Os $CODECOV_SHASUM_SIGNATURE_URL
+          gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM  \
+            && sha256sum --check codecov.SHA256SUM \
+            && ./codecov


### PR DESCRIPTION
## Code R Ticket
_Please provide a link to the Code R Jira ticket if applicable_

<https://partypeak.atlassian.net/browse/CODER-128>

## Description
Uses the binary Codecov uploader. Before execution we verify whether the uploader matches the published checksum and whether this checksum is signed by Codecov's PGP key.

## Dependencies
_Are there any dependencies in relation to pull requests in other Apollo repositories? If so please provide links to these pull requests_

*

## Additional notes
Nope
